### PR TITLE
Require Bundler 1.2 for multiple colors support from vendored Thor

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -7,4 +7,4 @@ email: postmodern.mod3@gmail.com
 homepage: https://github.com/postmodern/bundler-audit#readme
 
 dependencies:
-  bundler: ~> 1.0
+  bundler: ~> 1.2


### PR DESCRIPTION
First of all, thanks for this neat Gem - very relevant especially with the recent Rails security fixes.

So I've tried to run it against an old Rails project and although it did detect a couple of unpatached versions, the output looked wonky:

```
Criticality: [:red, :bold]High
```

Turned out I was using an old version of Bundler (1.1.3) tied with the old _Gemfile.lock_.
After some digging, I saw you're using [Thor vendored with Bundler](https://github.com/postmodern/bundler-audit/blob/master/lib/bundler/audit/cli.rb#L21).
But Thor supports [multiple color arrays since version 0.15](https://github.com/wycats/thor/blob/master/CHANGELOG.md) which has been [vendored in Bundler in version 1.2.0.rc](https://github.com/carlhuda/bundler/blob/master/CHANGELOG.md).

This fix ensures we have a recent enough vendored Thor that supports arrays as colors.
