### PR TITLE
Checkout ruby-advisory-db into spec/fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ Gemfile.lock
 doc/
 pkg/
 spec/bundle/*/Gemfile.lock
+spec/fixtures
 vendor/cache/*.gem

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,9 @@ require 'rubygems/tasks'
 Gem::Tasks.new
 
 require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "spec/*_spec.rb"
+end
 
 namespace :spec do
   task :bundle do
@@ -39,5 +41,5 @@ task :test    => :spec
 task :default => :spec
 
 require 'yard'
-YARD::Rake::YardocTask.new  
+YARD::Rake::YardocTask.new
 task :doc => :yard

--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -26,9 +26,10 @@ module Bundler
     # and CVE number.
     #
     class Database
-
       # directory containing advisories
-      PATH =  File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','data','ruby-advisory-db','gems'))
+      def self.path
+        File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','data','ruby-advisory-db','gems'))
+      end
 
       # The path to the advisory database
       attr_reader :path
@@ -42,7 +43,7 @@ module Bundler
       # @raise [ArgumentError]
       #   The path was not a directory.
       #
-      def initialize(path=PATH)
+      def initialize(path=self.class.path)
         unless File.directory?(path)
           raise(ArgumentError,"#{path.dump} is not a directory")
         end

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -3,7 +3,7 @@ require 'bundler/audit/database'
 require 'bundler/audit/advisory'
 
 describe Bundler::Audit::Advisory do
-  let(:root) { Bundler::Audit::Database::PATH }
+  let(:root) { Bundler::Audit::Database.path }
   let(:gem)  { 'actionpack' }
   let(:cve)  { '2013-0156' }
   let(:path) { File.join(root,gem,"#{cve}.yml") }

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -3,8 +3,8 @@ require 'bundler/audit/database'
 require 'tmpdir'
 
 describe Bundler::Audit::Database do
-  describe "PATH" do
-    subject { described_class::PATH }
+  describe ".path" do
+    subject { described_class.path }
 
     it "it should be a directory" do
       File.directory?(subject).should be_true
@@ -15,8 +15,8 @@ describe Bundler::Audit::Database do
     context "when given no arguments" do
       subject { described_class.new }
 
-      it "should default path to PATH" do
-        subject.path.should == described_class::PATH
+      it "should default path to path" do
+        subject.path.should == described_class.path
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,19 @@ module Helpers
 end
 
 include Bundler::Audit
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    unless File.exist?("spec/fixtures/ruby-advisory-db/gems")
+      FileUtils.mkdir_p("spec/fixtures")
+
+      Dir.chdir("spec/fixtures") do
+        system "git clone git://github.com/rubysec/ruby-advisory-db.git"
+      end
+    end
+  end
+
+  config.before do
+    Bundler::Audit::Database.stub(path: File.expand_path(File.join(File.dirname(__FILE__),'fixtures','ruby-advisory-db','gems')))
+  end
+end


### PR DESCRIPTION
Was getting 18 failures from running specs on a clean checkout. Now 3.

This isolates the DB for specs from the DB in data/ of your working copy, which should make development easier.

Now getting 3 fails locally (same as Travis).  I think the best approach is adding a `--db-path` option and pointing it to `spec/fixtures/ruby-advisory-db` during integration specs. Sound ok?
