### PR TITLE
Add Check For Insecure Sources

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -36,6 +36,8 @@ module Bundler
         vulnerable  = false
         lock_file   = load_gemfile_lock('Gemfile.lock')
 
+        check_sources(lock_file.sources)
+
         lock_file.specs.each do |gem|
           database.check_gem(gem) do |advisory|
             vulnerable = true
@@ -111,6 +113,15 @@ module Bundler
       def say(string="", color=nil)
         color = nil unless $stdout.tty?
         super(string, color)
+      end
+
+      def check_sources(sources)
+        insecure = sources.first.remotes.select {|source| source.scheme == 'http'}
+
+        if insecure.any?
+          say 'Warning: The following gem sources are not using SSL:', :yellow
+          insecure.each {|source| say(source, :yellow)}
+        end
       end
 
     end


### PR DESCRIPTION
This add basic checking of the Gemfile.lock for any sources not using SSL. Line 119 is a bit hacky as it expects all remotes to be in the first element of the Gemfile sources.
