### PR TITLE
Allow users to ignore advisories they know that they are not vulernable to for ci

### DIFF
--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -88,6 +88,18 @@ module Bundler
       end
 
       #
+      # Adds a patched version.
+      #
+      # @param [String] version
+      #   The version to be added
+      #
+      # @return [Array] list of all patched versions
+      #
+      def add_patched_version(version)
+        self.patched_versions << Gem::Requirement.new(version)
+      end
+
+      #
       # Converts the advisory to a String.
       #
       # @return [String]

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -30,9 +30,10 @@ module Bundler
 
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
       method_option :verbose, :type => :boolean, :aliases => '-v'
+      method_option :safe, :type => :array
 
       def check
-        database    = Database.new
+        database    = Database.new(:user_considers_safe => options[:safe])
         vulnerable  = false
         lock_file   = load_gemfile_lock('Gemfile.lock')
 

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -3,6 +3,8 @@ require 'bundler/audit/database'
 require 'tmpdir'
 
 describe Bundler::Audit::Database do
+  include Helpers
+
   describe "PATH" do
     subject { described_class::PATH }
 
@@ -13,8 +15,6 @@ describe Bundler::Audit::Database do
 
   describe "#initialize" do
     context "when given no arguments" do
-      subject { described_class.new }
-
       it "should default path to PATH" do
         subject.path.should == described_class::PATH
       end
@@ -23,7 +23,7 @@ describe Bundler::Audit::Database do
     context "when given a directory" do
       let(:path ) { Dir.tmpdir }
 
-      subject { described_class.new(path) }
+      subject { described_class.new(:path => path) }
 
       it "should set #path" do
         subject.path.should == path
@@ -33,7 +33,7 @@ describe Bundler::Audit::Database do
     context "when given an invalid directory" do
       it "should raise an ArgumentError" do
         lambda {
-          described_class.new('/foo/bar/baz')
+          described_class.new(:path => '/foo/bar/baz')
         }.should raise_error(ArgumentError)
       end
     end
@@ -49,16 +49,30 @@ describe Bundler::Audit::Database do
 
     context "when given a block" do
       it "should yield every advisory effecting the gem" do
-        advisories = []
-
-        subject.check_gem(gem) do |advisory|
-          advisories << advisory
-        end
-
-        advisories.should_not be_empty
+        advisories = advisories_for_gem(gem)
         advisories.all? { |advisory|
           advisory.kind_of?(Bundler::Audit::Advisory)
         }.should be_true
+      end
+
+      it "should yield advisories considered not safe by the user" do
+        advisories = advisories_for_gem(gem, :user_considers_safe => ["XXXX-0156@3.1.9"])
+        advisories.map(&:cve).should include("2013-0156")
+      end
+
+      it "should yield version of advisories considered not safe by the user" do
+        advisories = advisories_for_gem(gem, :user_considers_safe => ["2013-0156@3.1.8"])
+        advisories.map(&:cve).should include("2013-0156")
+      end
+
+      it "should not yield advisories considered safe by the user" do
+        advisories = advisories_for_gem(gem, :user_considers_safe => ["2013-0156@3.1.9"])
+        advisories.map(&:cve).should_not include("2013-0156")
+      end
+
+      it "should ignore all versions of a gem when no version was given for advisory ignore" do
+        advisories = advisories_for_gem(gem, :user_considers_safe => ["2013-0156"])
+        advisories.map(&:cve).should_not include("2013-0156")
       end
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "CLI" do
   include Helpers
 
-  let(:command) do
+  let(:executable) do
     File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundle-audit'))
   end
 
@@ -12,7 +12,7 @@ describe "CLI" do
     let(:directory) { File.join('spec','bundle',bundle) }
 
     subject do
-      Dir.chdir(directory) { sh(command, :fail => true) }
+      Dir.chdir(directory) { sh(executable, :fail => true) }
     end
 
     it "should print a warning" do
@@ -46,6 +46,19 @@ Title: Ruby on Rails Active Record JSON Parameter Parsing Query Bypass
 Solution: upgrade to ~> 2.3.16, ~> 3.0.19, ~> 3.1.10, >= 3.2.11
       }.strip)
     end
+
+    context "when ignoring warnings" do
+      it "still prints warnings that are not ignored" do
+        out = Dir.chdir(directory) { sh("#{executable} --safe 2013-0155@3.2.10", :fail => true) }
+        out.should include "CVE: 2013-0276"
+        out.should_not include "CVE: 2013-0155"
+      end
+
+      it "prints no warnings if all warnings are ignored" do
+        out = Dir.chdir(directory) { sh("#{executable} --safe 2013-0155@3.2.10 2013-0276@3.2.10 2013-0156@3.2.10") }
+        out.strip.should == "No unpatched versions found"
+      end
+    end
   end
 
   context "when auditing a secure bundle" do
@@ -53,7 +66,7 @@ Solution: upgrade to ~> 2.3.16, ~> 3.0.19, ~> 3.1.10, >= 3.2.11
     let(:directory) { File.join('spec','bundle',bundle) }
 
     subject do
-      Dir.chdir(directory) { sh(command) }
+      Dir.chdir(directory) { sh(executable) }
     end
 
     it "should print nothing when everything is fine" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,16 @@ module Helpers
   def decolorize(string)
     string.gsub(/\e\[\d+m/, "")
   end
+
+  def advisories_for_gem(gem, database_options={})
+    subject = Database.new(database_options)
+    advisories = []
+
+    subject.check_gem(gem) do |advisory|
+      advisories << advisory
+    end
+    advisories
+  end
 end
 
 include Bundler::Audit


### PR DESCRIPTION
We are running bundler-audit on our ci, but a few vulnerabilities are unfixable for us (stuck on rails 2) or not relevant(sql injection vulnerability vs project that does not use params).
To get a green ci build/to see when something new breaks we would like to ignore those specific CVEs for the given version (it's okay if it pops up again if we upgraded our version, a nice reminder)
