### PR TITLE
allow to ignore cve for specific version

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -83,7 +83,7 @@ module Bundler
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
-            unless ignore.include?("CVE-#{advisory.cve}")
+            unless ignored?(gem, advisory, ignore)
               yield UnpatchedGem.new(gem,advisory)
             end
           end
@@ -92,6 +92,15 @@ module Bundler
         return self
       end
 
+      private
+
+      def ignored?(gem, advisory, ignores)
+        ignores.any? do |ignore|
+          ignored_cve, ignored_version = ignore.split("@")
+          ignored_cve == "CVE-#{advisory.cve}" &&
+            (!ignored_version || Gem::Requirement.new(ignored_version).satisfied_by?(gem.version))
+        end
+      end
     end
   end
 end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -44,6 +44,18 @@ describe Scanner do
         
         cves.should_not include('2013-0156')
       end
+
+      it "should ignore matching gem versions" do
+        subject = scanner.scan(:ignore => ['CVE-2013-0156@~>3.2.10'])
+        cves = subject.map { |result| result.advisory.cve }
+        cves.should_not include('2013-0156')
+      end
+
+      it "should not ignore non-matching gem versions" do
+        subject = scanner.scan(:ignore => ['CVE-2013-0156@~>3.2.11'])
+        cves = subject.map { |result| result.advisory.cve }
+        cves.should include('2013-0156')
+      end
     end
   end
 


### PR DESCRIPTION
for example an unupgradable rails 2 would be `--ignore "2012-1098@~>2.3.18"`

It will be used for [organization-audit](https://github.com/grosser/bundler-organization_audit) where 1 set of rules is ran against all repos, making it necessary to ignore specific things that are safe on 1 version but not on another.

@postmodern
