### PR TITLE
Add --consider-git-uris-safe option to CLI.

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -31,12 +31,13 @@ module Bundler
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
+      method_option :consider_git_uris_safe, :type => :boolean
 
       def check
         scanner    = Scanner.new
         vulnerable = false
 
-        scanner.scan(:ignore => options.ignore) do |result|
+        scanner.scan(:ignore => options.ignore, :consider_git_uris_safe => options.consider_git_uris_safe) do |result|
           vulnerable = true
 
           case result

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -50,6 +50,9 @@ module Bundler
       # @option options [Array<String>] :ignore
       #   The advisories to ignore.
       #
+      # @option options [Boolean] :consider_git_uris_safe
+      #   Do not warn about source URIs starting with "git:"
+      #
       # @yield [result]
       #   The given block will be passed the results of the scan.
       #
@@ -69,8 +72,10 @@ module Bundler
           case source
           when Source::Git
             case source.uri
-            when /^git:/, /^http:/
+            when /^http:/
               yield InsecureSource.new(source.uri)
+            when /^git:/
+              yield InsecureSource.new(source.uri) unless options[:consider_git_uris_safe]
             end
           when Source::Rubygems
             source.remotes.each do |uri|

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -83,6 +83,17 @@ Insecure Source URI found: git://github.com/rails/jquery-rails.git
 Insecure Source URI found: http://rubygems.org/
       }.strip)
     end
+
+    context "when the --consider-git-uris-safe option is given" do
+      let(:command) do
+        File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundle-audit --consider-git-uris-safe'))
+      end
+
+      it "should only warn about http sources" do
+        subject.should include("Insecure Source URI found: http://rubygems.org/")
+        subject.should_not include("Insecure Source URI found: git://github.com/rails/jquery-rails.git")
+      end
+    end
   end
 
   context "when auditing a secure bundle" do

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -54,9 +54,17 @@ describe Scanner do
 
     subject { scanner.scan.to_a }
 
-    it "should match unpatched gems to their advisories" do
+    it "should warn about the insecure sources" do
       subject[0].source.should == 'git://github.com/rails/jquery-rails.git'
       subject[1].source.should == 'http://rubygems.org/'
+    end
+
+    context "when the :consider_git_uris_safe option is given" do
+      subject { scanner.scan(:consider_git_uris_safe => true).to_a }
+
+      it "should only warn about http sources" do
+        subject.map(&:source).should == ['http://rubygems.org/']
+      end
     end
   end
 


### PR DESCRIPTION
This allows using bundler-audit for Gemfiles using the `github:` shorthand syntax.

Bundler expands `github:` to `git://github.com`. A pull request changing this to `https:` has not been accepted, as the developers of bundler do not consider `git:` as inherently unsafe: https://github.com/bundler/bundler/pull/1820

PS: I'm not 100% sure about the name of the option – if anyone comes up with a better name I’ll be happy to change it :smiley: 
