### PR TITLE
Add --secure-source option

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -31,12 +31,14 @@ module Bundler
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
+      method_option :secure_source, :type => :array
 
       def check
         scanner    = Scanner.new
         vulnerable = false
 
-        scanner.scan(:ignore => options.ignore) do |result|
+        scanner.scan(:ignore => options.ignore,
+                     :secure_sources => options.secure_source) do |result|
           vulnerable = true
 
           case result

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -65,10 +65,19 @@ module Bundler
         ignore = Set[]
         ignore += options[:ignore] if options[:ignore]
 
+
+        secure_source_regexp = Regexp.new(
+          Array(options[:secure_source]).map do |source|
+            "^#{Regexp.escape source}"
+          end.join('|')
+        )
+
         @lockfile.sources.map do |source|
           case source
           when Source::Git
             case source.uri
+            when secure_source_regexp
+              # Do nothing
             when /^git:/, /^http:/
               yield InsecureSource.new(source.uri)
             end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -54,9 +54,17 @@ describe Scanner do
 
     subject { scanner.scan.to_a }
 
-    it "should match unpatched gems to their advisories" do
+    it "should match the insecure sources" do
       subject[0].source.should == 'git://github.com/rails/jquery-rails.git'
       subject[1].source.should == 'http://rubygems.org/'
+    end
+
+    context "when sources are in :secure_sources" do
+      subject { scanner.scan(:secure_sources => ['git://github.com', 'http://']) }
+
+      it "should not match those sources as insecure" do
+        subject.should be_empty
+      end
     end
   end
 


### PR DESCRIPTION
This option can override the insecure sources check against http:// and
git:// sources. It allows specific url prefixes (such as an internal git
mirror) to be excluded from the check.

@postmodern I noticed you rejected a similar pull in #37, but please reconsider. I think it is sufficient for the insecure source check to just be a default - there are legitimate reasons to use git:// sources. In my company's case, we use an internal git:// mirror in part for performance reasons, which is still arguably more secure than any 3rd party source.
