### PR TITLE
Make tests resilient to gemfile changes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,10 +44,9 @@ namespace :spec do
         begin
           sh 'BUNDLE_BIN_PATH="" BUNDLE_GEMFILE="" RUBYOPT="" bundle install --path ../../../vendor/bundle'
         rescue
-          if(File.exist?("Gemfile.lock"))
-            puts "Looks like Gemfile may have been updated.  Attempting to update things."
-            sh 'BUNDLE_BIN_PATH="" BUNDLE_GEMFILE="" RUBYOPT="" bundle update'
-          end
+          exit(1) if(!File.exist?('Gemfile.lock'))
+          puts "Looks like Gemfile may have been updated.  Attempting to update things."
+          sh 'BUNDLE_BIN_PATH="" BUNDLE_GEMFILE="" RUBYOPT="" bundle update'
         end
       end
     end


### PR DESCRIPTION
Recent change to bump Ruby version in the secure test caused chaos because of the pre-existing Gemfile.lock.  Removing Gemfile.lock before running tests is needlessly slow.  Catching a failed bundle install and trying a bundle update works for these scenarios.
