### PR TITLE
Make tests more resilient

### DIFF
--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -7,6 +7,15 @@ describe Bundler::Audit::Advisory do
   let(:gem)  { 'actionpack' }
   let(:id)   { 'OSVDB-84243' }
   let(:path) { File.join(root,'gems',gem,"#{id}.yml") }
+  let(:an_unaffected_version) do
+    YAML.
+      load(File.read(path))['unaffected_versions'].
+      map { |item| item.split(/\s*,\s*/) }.
+      flatten.
+      select { |ver| ver =~ /^(~>|>=|=|<=)/ }.
+      first.
+      sub(/^.*?(~>|>=|=|<=)\s+/, '')
+  end
 
   describe "load" do
     let(:data) { YAML.load_file(path) }
@@ -58,7 +67,7 @@ describe Bundler::Audit::Advisory do
     subject { described_class.load(path) }
 
     context "when passed a version that matches one unaffected version" do
-      let(:version) { Gem::Version.new('2.3.10') }
+      let(:version) { Gem::Version.new(an_unaffected_version) }
 
       it "should return true" do
         subject.unaffected?(version).should be_true
@@ -116,7 +125,7 @@ describe Bundler::Audit::Advisory do
         subject { described_class.load(path) }
      
         context "when passed a version that matches one unaffected version" do
-          let(:version) { Gem::Version.new('2.3.12') }
+          let(:version) { Gem::Version.new(an_unaffected_version) }
 
           it "should return false" do
             subject.vulnerable?(version).should be_false

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -20,67 +20,16 @@ describe "CLI" do
     end
 
     it "should print advisory information for the vulnerable gems" do
-      expect = %{
-Name: actionpack
-Version: 3.2.10
-Advisory: OSVDB-91452
-Criticality: Medium
-URL: http://www.osvdb.org/show/osvdb/91452
-Title: XSS vulnerability in sanitize_css in Action Pack
-Solution: upgrade to ~> 2.3.18, ~> 3.1.12, >= 3.2.13
+      advisory_pattern = /(Name: [^\n]+
+Version: \d+.\d+.\d+
+Advisory: OSVDB-\d+
+Criticality: (High|Medium)
+URL: http:\/\/(direct|www\.)?osvdb.org\/show\/osvdb\/\d+
+Title: [^\n]*?
+Solution: upgrade to ((~>|=>) \d+.\d+.\d+, )*(~>|=>) \d+.\d+.\d+[\s\n]*?)+/
 
-Name: actionpack
-Version: 3.2.10
-Advisory: OSVDB-91454
-Criticality: Medium
-URL: http://osvdb.org/show/osvdb/91454
-Title: XSS Vulnerability in the `sanitize` helper of Ruby on Rails
-Solution: upgrade to ~> 2.3.18, ~> 3.1.12, >= 3.2.13
-
-Name: actionpack
-Version: 3.2.10
-Advisory: OSVDB-89026
-Criticality: High
-URL: http://osvdb.org/show/osvdb/89026
-Title: Ruby on Rails params_parser.rb Action Pack Type Casting Parameter Parsing Remote Code Execution
-Solution: upgrade to ~> 2.3.15, ~> 3.0.19, ~> 3.1.10, >= 3.2.11
-
-Name: activerecord
-Version: 3.2.10
-Advisory: OSVDB-91453
-Criticality: High
-URL: http://osvdb.org/show/osvdb/91453
-Title: Symbol DoS vulnerability in Active Record
-Solution: upgrade to ~> 2.3.18, ~> 3.1.12, >= 3.2.13
-
-Name: activerecord
-Version: 3.2.10
-Advisory: OSVDB-90072
-Criticality: Medium
-URL: http://direct.osvdb.org/show/osvdb/90072
-Title: Ruby on Rails Active Record attr_protected Method Bypass
-Solution: upgrade to ~> 2.3.17, ~> 3.1.11, >= 3.2.12
-
-Name: activerecord
-Version: 3.2.10
-Advisory: OSVDB-89025
-Criticality: High
-URL: http://osvdb.org/show/osvdb/89025
-Title: Ruby on Rails Active Record JSON Parameter Parsing Query Bypass
-Solution: upgrade to ~> 2.3.16, ~> 3.0.19, ~> 3.1.10, >= 3.2.11
-
-Name: activesupport
-Version: 3.2.10
-Advisory: OSVDB-91451
-Criticality: High
-URL: http://www.osvdb.org/show/osvdb/91451
-Title: XML Parsing Vulnerability affecting JRuby users
-Solution: upgrade to ~> 3.1.12, >= 3.2.13
-
-Unpatched versions found!
-      }.strip.split "\n\n"
-
-      subject.strip.split("\n\n").should =~ expect
+      expect(subject).to match(advisory_pattern)
+      expect(subject).to include("Unpatched versions found!")
     end
   end
 


### PR DESCRIPTION
Since any arbitrary version we pick could have a vulnerability discovered down the road, and we're using the current DB rather than a fixed snapshot for testing, let's automatically pick a known-not-vulnerable version for such tests.
