### PR TITLE
RubyGems 1.8 adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Audit a projects `Gemfile.lock`:
 ## Requirements
 
 * [bundler] ~> 1.2
+* [RubyGems] >= 1.8
 
 ## Install
 
@@ -109,3 +110,5 @@ along with bundler-audit.  If not, see <http://www.gnu.org/licenses/>.
 [bundler]: https://github.com/carlhuda/bundler#readme
 
 [OSVDB]: http://osvdb.org/
+
+[RubyGems]: https://rubygems.org

--- a/bundler-audit.gemspec
+++ b/bundler-audit.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |gem|
   gem.executables = gemspec.fetch('executables') do
     glob['bin/*'].map { |path| File.basename(path) }
   end
-  gem.default_executable = gem.executables.first if Gem::VERSION < '1.7.'
 
   gem.extensions       = glob[gemspec['extensions'] || 'ext/**/extconf.rb']
   gem.test_files       = glob[gemspec['test_files'] || '{test/{**/}*_test.rb']


### PR DESCRIPTION
Since RubyGems < 1.8 is explicitly unsupported, there's no sense in kinda-sorta supporting old versions.

Also, we should call out the dependency in the README.
