### PR TITLE
Add SimpleCov into the mix to get C0 coverage stats.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Gemfile.lock
 doc/
+coverage/
 pkg/
 spec/bundle/*/Gemfile.lock
 vendor/bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development do
   gem 'rubygems-tasks', '~> 0.2'
   gem 'rspec',          '~> 2.4'
   gem 'yard',           '~> 0.8'
+  gem 'simplecov',      '~> 0.7', :require => false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,10 @@
+version = RUBY_VERSION.split(/\./).map(&:to_i)
+if((version[0] == 1 && version[1] >= 9) || (version[0] >= 2))
+  require 'simplecov'
+  require 'json'
+  SimpleCov.start
+end
+
 require 'rspec'
 require 'bundler/audit/version'
 


### PR DESCRIPTION
Plug in SimpleCov, as even the minimal guarantees provided by C0 coverage can prove handy for a security-related tool.
