### PR TITLE
Update the database test

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -86,7 +86,7 @@ module Bundler
         say gem.name
 
         say "Version: ", :red
-        say gem.version
+        say gem.version.to_s
 
         say "Advisory: ", :red
         say advisory.id

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -19,10 +19,16 @@ describe Bundler::Audit::Database do
       Bundler::Audit::Database.update!
 
       # As up to date...
-      expect(Bundler::Audit::Database.path).to eq mocked_user_path
+      expect do
+        # Stub the Vendor copy to be the exact same as the user path copy
+        stub_const("Bundler::Audit::Database::VENDORED_TIMESTAMP", Dir.chdir(mocked_user_path) { Time.parse(`git log --pretty="%cd" -1`) })
+        # When they are the exact same prefer the user copy
+        expect(Bundler::Audit::Database.path).to eq mocked_user_path
+      end
 
       # More up to date...
       fake_a_commit_in_the_user_repo
+      # Prefer the newset, in this case user repo
       expect(Bundler::Audit::Database.path).to eq mocked_user_path
 
       # Roll the advisory-db back until its older than the one checked in this could

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,12 @@ module Helpers
       system 'git', 'checkout', 'master'
     end
   end
+
+  def roll_user_repo_back_until(&block)
+    while not yield
+      roll_user_repo_back(1)
+    end
+  end
 end
 
 include Bundler::Audit


### PR DESCRIPTION
This test should now walk back the `advisory-db` chain until it is older than the `vendor` database. Then the condition holds true and should pass. Previously it walked back 2 commits which would not always be older than `vendor`.
