### PR TITLE
Fix for thor gem version output error

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -87,7 +87,7 @@ module Bundler
         say gem.name
 
         say "Version: ", :red
-        say gem.version
+        say gem.version.to_s
 
         say "Advisory: ", :red
         say advisory.id


### PR DESCRIPTION
Wherein Gem::Version#version doesn't behave like a string enough for thor's liking.
