### PR TITLE
Add ignore example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,4 @@ along with bundler-audit.  If not, see <http://www.gnu.org/licenses/>.
 [bundler]: https://github.com/carlhuda/bundler#readme
 
 [OSVDB]: http://osvdb.org/
+[ruby-advisory-db]: https://github.com/rubysec/ruby-advisory-db


### PR DESCRIPTION
Add an example of using the `--ignore` option. 

It also adds a link to the ruby-advisory-db that looks like it was missing from the markdown syntax.
