### PR TITLE
Update PR to not print Unpatched versions found' if only insecure sources found

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -60,10 +60,10 @@ module Bundler
             print_advisory result.gem, result.advisory
           end
           end
-          puts JSON.pretty_generate(@array) if !@array.empty?
         end
 
         if vulnerable
+          puts JSON.pretty_generate(@array) if !@array.empty?
           say "Unpatched versions found!", :red unless !unpatched_versions || options.json?
           exit 1
         else


### PR DESCRIPTION
This is a minor change to remove the unpatched version message if bundler-audit only finds insecure sources.
