### PR TITLE
Switched to using the ruby-git gem

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -12,3 +12,4 @@ required_rubygems_version: ">= 1.8.0"
 dependencies:
   thor: ~> 0.18
   bundler: ~> 1.2
+  git: ~> 1.2


### PR DESCRIPTION
We have been getting some zombies of the git processes that were failing. We run a bundler-audit on our servers every now and then, whenever GitHub fails we are left with a git zombie process. 

By using the Ruby git gem I am hoping to prevent that. It also removes some magic with commands being tossed around, it is replaced by one more dependency though.

Feel free to reject if you are not interested in having the change in master :)