### PR TITLE
Support path option

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -32,12 +32,13 @@ module Bundler
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
+      method_option :path, :type => :string, :aliases => '-p', :default => Dir.pwd
       method_option :update, :type => :boolean, :aliases => '-u'
 
       def check
         update if options[:update]
 
-        scanner    = Scanner.new
+        scanner    = Scanner.new(options[:path])
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -50,6 +50,22 @@ Solution: upgrade to ((~>|=>) \d+.\d+.\d+, )*(~>|=>) \d+.\d+.\d+[\s\n]*?)+/
     end
   end
 
+  context "when auditing a bundle with insecure sources with path option" do
+    let(:bundle)    { 'insecure_sources' }
+    let(:directory) { File.join('spec','bundle',bundle) }
+    let(:command) do
+      File.expand_path(File.join(File.dirname(__FILE__),'..','bin',"bundle-audit -p #{directory}"))
+    end
+    let(:subject) { sh(command, :fail => true) }
+
+    it "should print warnings about insecure sources" do
+      subject.should include(%{
+Insecure Source URI found: git://github.com/rails/jquery-rails.git
+Insecure Source URI found: http://rubygems.org/
+      }.strip)
+    end
+  end
+
   context "when auditing a bundle with insecure sources" do
     let(:bundle)    { 'insecure_sources' }
     let(:directory) { File.join('spec','bundle',bundle) }


### PR DESCRIPTION
Add support for `path` to specify where to scan a `Gemfile.lock` file. Related with #74

Added integration test to test the new flag. 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rubysec/bundler-audit/87)

<!-- Reviewable:end -->
