### PR TITLE
Add option to update before running check

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Update the [ruby-advisory-db] that `bundle-audit` uses:
      create mode 100644 gems/wicked/OSVDB-98270.yml
     ruby-advisory-db: 64 advisories
 
+Update the [ruby-advisory-db] and check `Gemfile.lock` (useful for CI runs):
+
+    $ bundle-audit check --update
+
 Ignore specific advisories:
 
     $ bundle-audit check --ignore OSVDB-108664

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -32,8 +32,11 @@ module Bundler
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
+      method_option :update, :type => :boolean, :aliases => '-u'
 
       def check
+        update if options[:update]
+
         scanner    = Scanner.new
         vulnerable = false
 


### PR DESCRIPTION
I've integrated bundler-audit into our CI (it's fantastic btw, thanks for all the work on this).

However, it's difficult to run more than one command at a time. Right now I'm solving this with a script which runs `bundle-audit update && bundle-audit check`, but I figured it would make sense to natively support the option to update the database and run a check in a single command.

Let me know what you think.