### PR TITLE
Force git to use iso8601 dates explicitly for repo modification times

### DIFF
--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -68,7 +68,7 @@ module Bundler
       #
       def self.path
         if File.directory?(USER_PATH)
-          t1 = Dir.chdir(USER_PATH) { Time.parse(`git log --pretty="%cd" -1`) }
+          t1 = Dir.chdir(USER_PATH) { Time.parse(`git log --date=iso8601 --pretty="%cd" -1`) }
           t2 = VENDORED_TIMESTAMP
 
           if t1 >= t2 then USER_PATH


### PR DESCRIPTION
When a user of `bundler-audit` has the following in his `~/.gitconfig`

```
[log]
  date = relative
```

...then `bundle-audit update` and subsequent `bundle-audit` would fail with 

```
/usr/local/var/rbenv/versions/2.1.5/lib/ruby/2.1.0/time.rb:327:in `parse': no time information in "2 days ago\n" (ArgumentError)
	from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-audit-0.3.1/lib/bundler/audit/database.rb:71
```

This PR forces the `git` invocation to use ISO8601 formatting which can be correctly parsed by Ruby's Time class.