### PR TITLE
Bug ignoring CVE-2015-3448

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -91,11 +91,7 @@ module Bundler
 
         say "Advisory: ", :red
 
-        if advisory.cve
-          say "CVE-#{advisory.cve}"
-        elsif advisory.osvdb
-          say advisory.osvdb
-        end
+        say advisory.id
 
         say "Criticality: ", :red
         case advisory.criticality

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -22,7 +22,7 @@ describe "CLI" do
     it "should print advisory information for the vulnerable gems" do
       advisory_pattern = /(Name: [^\n]+
 Version: \d+.\d+.\d+
-Advisory: CVE-[0-9]{4}-[0-9]{4}
+Advisory: (OSVDB-[0-9]{5,6}|CVE-[0-9]{4}-[0-9]{4})
 Criticality: (High|Medium)
 URL: http:\/\/(direct|www\.)?osvdb.org\/show\/osvdb\/\d+
 Title: [^\n]*?


### PR DESCRIPTION
# The problem

I've found a bug ignoring `CVE-2015-3448`.

```
$ bundle exec bundle-audit check --ignore CVE-2015-3448 CVE-2015-1820 CVE-2015-3227
Name: rest-client
Version: 1.6.9
Advisory: CVE-2015-3448
Criticality: Unknown
URL: http://www.osvdb.org/show/osvdb/117461
Title: Rest-Client Gem for Ruby logs password information in plaintext
Solution: upgrade to >= 1.7.3

Vulnerabilities found!
```

Debugging it I figured out that the advisory ID is not `CVE-2015-3448` but `OSVDB-117461`.

```
#<struct Bundler::Audit::Advisory
 path="/Users/tapajos/.local/share/ruby-advisory-db/gems/rest-client/OSVDB-117461.yml",
 id="OSVDB-117461",
 url="http://www.osvdb.org/show/osvdb/117461",
 title="Rest-Client Gem for Ruby logs password information in plaintext",
 description="Rest-Client Ruby Gem contains a flaw that is due to the application logging password information in plaintext. This may allow a local attacker to gain access to password information.",
 cvss_v2=nil,
 cve="2015-3448",
 osvdb=117461,
 unaffected_versions=[],
 patched_versions=[Gem::Requirement.new([">= 1.7.3"])]>
```

CLI is printing the Advisory based on the code bellow but it seems to be wrong because (looks like) an advisory can be `advisory.cve` and `advisory.osvdb` at the same time.

``` ruby
if advisory.cve
    say "CVE-#{advisory.cve}"
elsif advisory.osvdb
    say advisory.osvdb
end
```
# The fix

I put a really simple fix printing the `advisory.id` (what we need to add in ignore list)
