### PR TITLE
better non CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ Ignore specific advisories:
 
     $ gem install bundler-audit
 
+## Non-CLI Usage
+
+Besides using `bundle-audit` on the command line you can use it programmatically, too. This is especially interesting if you want to audit several repositories at once.
+
+    #!/usr/bin/env ruby
+    
+    require 'bundler/audit/scanner'
+    
+    %w(/path/to/ruby/repo1 /path/to/ruby/repo2).each do |repo_path|
+      puts "------------- #{repo}"
+      scanner = Bundler::Audit::Scanner.new(repo_path)
+      scanner.scan() do |result|
+        puts result
+      end
+    end
+
 ## License
 
 Copyright (c) 2013-2015 Hal Brodigan (postmodern.mod3 at gmail.com)

--- a/lib/bundler/audit/insecure_source.rb
+++ b/lib/bundler/audit/insecure_source.rb
@@ -1,0 +1,30 @@
+# Represents a plain-text source
+module Bundler
+  module Audit
+    class InsecureSource
+
+      # The repository source url
+      #
+      # @return [String]
+      attr_accessor :source
+
+      #
+      # Initializes an unpatched gem.
+      #
+      # @param [String] source
+      #   The repository source url
+      def initialize(source)
+        @source = source
+      end
+
+      #
+      # Returns relevant details about an insecure source.
+      #
+      # @return [String]
+      #
+      def to_s
+        "Insecure Source URI found: #{self.source}"
+      end
+    end
+  end
+end

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -1,5 +1,7 @@
 require 'bundler'
 require 'bundler/audit/database'
+require 'bundler/audit/unpatched_gem'
+require 'bundler/audit/insecure_source'
 require 'bundler/lockfile_parser'
 
 require 'ipaddr'
@@ -10,12 +12,6 @@ require 'uri'
 module Bundler
   module Audit
     class Scanner
-
-      # Represents a plain-text source
-      InsecureSource = Struct.new(:source)
-
-      # Represents a gem that is covered by an Advisory
-      UnpatchedGem = Struct.new(:gem, :advisory)
 
       # The advisory database
       #
@@ -145,7 +141,7 @@ module Bundler
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
             unless ignore.include?(advisory.id)
-              yield UnpatchedGem.new(gem,advisory)
+              yield UnpatchedGem.new(gem,advisory,options[:verbose])
             end
           end
         end

--- a/lib/bundler/audit/unpatched_gem.rb
+++ b/lib/bundler/audit/unpatched_gem.rb
@@ -1,0 +1,79 @@
+# Represents a gem that is covered by an Advisory
+module Bundler
+  module Audit
+    class UnpatchedGem
+
+      # The gem
+      #
+      # @return [Gem]
+      attr_reader :gem
+
+      # The advisory
+      #
+      # @return [Advisory]
+      attr_accessor :advisory
+
+      # The verbosity flag
+      #
+      # @return [Boolean]
+      attr_accessor :verbose
+
+      #
+      # Initializes an unpatched gem.
+      #
+      # @param [Gem] gem
+      #   The Gem which is audited
+      #
+      # @param [Advisory] advisory
+      #   The advisory
+      #
+      # @param [Bool] verbose
+      #   Be more verbose if true.
+      #
+      def initialize(gem,advisory,verbose=false)
+        @gem      = gem
+        @advisory = advisory
+        @verbose  = verbose
+      end
+
+      #
+      # Returns relevant details about an insecure gem.
+      #
+      # @return [String]
+      #
+      def to_s
+        str = ''
+        str << "Name: #{self.gem.name}\n"
+        str << "Version: #{self.gem.version}\n"
+        str << "Advisory: #{self.advisory.cve ? "CVE-#{advisory.cve}" : advisory.osvdb}\n"
+        str << "Criticality: "
+
+        str << case self.advisory.criticality
+        when :low    then "Low"
+        when :medium then "Medium"
+        when :high   then "High"
+        else              "Unknown"
+        end
+        str << "\n"
+
+        str << "URL: #{self.advisory.url}\n"
+
+        if verbose
+          str << "Description: \n #{self.advisory.description}\n"
+        else
+          str << "Title: #{self.advisory.title}\n"
+        end
+
+        unless self.advisory.patched_versions.empty?
+          str << "Solution: upgrade to \n"
+          str << self.advisory.patched_versions.join(', ') + "\n"
+        else
+          str << "Solution: remove or disable this gem until a patch is available!"
+        end
+
+        str
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Especially if you want to audit many repositories at once you want to have more control over the auditing process and the output usage. In this PR I'd like to encourage the reader to use bundler-audit programmatically.
