### PR TITLE
Add ability to specify the Lockfile to check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .ruby-version
 .ruby-gemset
-Gemfile.lock
+/Gemfile.lock
 doc/
 .yardoc/
 coverage/

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -29,12 +29,12 @@ module Bundler
       default_task :check
       map '--version' => :version
 
-      desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
+      desc 'check PATH', 'Checks PATH for insecure dependencies. If PATH is a directory, check PATH/Gemfile.lock'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
 
-      def check
-        scanner    = Scanner.new
+      def check(path=Dir.pwd)
+        scanner    = Scanner.new(path)
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -33,15 +33,18 @@ module Bundler
       #
       # Initializes a scanner.
       #
-      # @param [String] root
-      #   The path to the project root.
+      # @param [String] path
+      #   The path to the project root or a Gemfile.lock.
       #
-      def initialize(root=Dir.pwd)
-        @root     = File.expand_path(root)
+      def initialize(path=Dir.pwd)
+        path = File.expand_path(path)
+        if File.directory?(path)
+          path = File.join(path, "Gemfile.lock")
+        end
+
+        @root = File.dirname(path)
         @database = Database.new
-        @lockfile = LockfileParser.new(
-          File.read(File.join(@root,'Gemfile.lock'))
-        )
+        @lockfile = LockfileParser.new(File.read(path))
       end
 
       #

--- a/spec/fixtures/Gemfile.lock
+++ b/spec/fixtures/Gemfile.lock
@@ -1,0 +1,319 @@
+GIT
+  remote: git://github.com/bkeepers/qu.git
+  revision: d098e2657c92e89a6413bebd9c033930759c061f
+  branch: master
+  specs:
+    qu (0.2.0)
+    qu-rails (0.2.0)
+      qu (= 0.2.0)
+      railties (>= 3.2, < 5)
+    qu-redis (0.2.0)
+      qu (= 0.2.0)
+      redis-namespace
+
+GIT
+  remote: git://github.com/mikel/mail.git
+  revision: b159e0a542962fdd5e292a48cfffa560d7cf412e
+  specs:
+    mail (2.6.3.edge)
+      mime-types (>= 1.16, < 3)
+
+GIT
+  remote: git://github.com/rails/arel.git
+  revision: aac9da257f291ad8d2d4f914528881c240848bb2
+  branch: master
+  specs:
+    arel (7.0.0.alpha)
+
+GIT
+  remote: git://github.com/rails/globalid.git
+  revision: 4df66fb9e9f0c832d29119aa8bc30be55a614b71
+  specs:
+    globalid (0.3.5)
+      activesupport (>= 4.1.0)
+
+GIT
+  remote: git://github.com/rails/jquery-rails.git
+  revision: 272abdd319bb3381b23182b928b25320590096b0
+  branch: master
+  specs:
+    jquery-rails (4.0.3)
+      rails-dom-testing (~> 1.0)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+
+GIT
+  remote: git://github.com/rails/sprockets-rails.git
+  revision: 85b89c44ad40af3056899808475e6e4bf65c1f5a
+  branch: master
+  specs:
+    sprockets-rails (3.0.0.beta1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0, < 4.0)
+
+PATH
+  remote: .
+  specs:
+    actionmailer (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      rack (~> 1.6)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activejob (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      globalid (>= 0.3.0)
+    activemodel (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      builder (~> 3.1)
+    activerecord (5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      arel (= 7.0.0.alpha)
+    activesupport (5.0.0.alpha)
+      concurrent-ruby (~> 0.9.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    rails (5.0.0.alpha)
+      actionmailer (= 5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activerecord (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.0.alpha)
+      sprockets-rails
+    railties (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    amq-protocol (1.9.2)
+    backburner (0.4.6)
+      beaneater (~> 0.3.1)
+      dante (~> 0.1.5)
+    bcrypt (3.1.10)
+    bcrypt (3.1.10-x64-mingw32)
+    bcrypt (3.1.10-x86-mingw32)
+    beaneater (0.3.3)
+    benchmark-ips (2.1.1)
+    builder (3.2.2)
+    bunny (1.7.0)
+      amq-protocol (>= 1.9.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    coffee-rails (4.1.0)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 5.0)
+    coffee-script (2.3.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.0)
+    columnize (0.9.0)
+    concurrent-ruby (0.9.0)
+    connection_pool (2.1.1)
+    dalli (2.7.2)
+    dante (0.1.5)
+    delayed_job (4.0.6)
+      activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
+    erubis (2.7.0)
+    execjs (2.3.0)
+    hitimes (1.2.2)
+    hitimes (1.2.2-x86-mingw32)
+    i18n (0.7.0)
+    json (1.8.2)
+    kindlerb (0.1.1)
+      mustache
+      nokogiri
+    loofah (2.0.1)
+      nokogiri (>= 1.5.9)
+    metaclass (0.0.4)
+    method_source (0.8.2)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
+    minitest (5.3.3)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    mono_logger (1.1.0)
+    multi_json (1.11.0)
+    mustache (1.0.0)
+    mysql (2.9.1)
+    mysql2 (0.3.18)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x64-mingw32)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x86-mingw32)
+      mini_portile (~> 0.6.0)
+    pg (0.18.1)
+    psych (2.0.13)
+    que (0.9.2)
+    queue_classic (3.1.0)
+      pg (>= 0.17, < 0.19)
+    racc (1.4.12)
+    rack (1.6.0)
+    rack-cache (1.2)
+      rack (>= 0.4)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.6)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6.0)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.2)
+      loofah (~> 2.0)
+    rake (10.4.2)
+    rdoc (4.2.0)
+    redcarpet (3.2.3)
+    redis (3.2.1)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    resque-scheduler (4.0.0)
+      mono_logger (~> 1.0)
+      redis (~> 3.0)
+      resque (~> 1.25)
+      rufus-scheduler (~> 3.0)
+    rufus-scheduler (3.0.9)
+      tzinfo
+    sdoc (0.4.1)
+      json (~> 1.7, >= 1.7.7)
+      rdoc (~> 4.0)
+    sequel (4.19.0)
+    serverengine (1.5.10)
+      sigdump (~> 0.2.2)
+    sidekiq (3.3.2)
+      celluloid (>= 0.16.0)
+      connection_pool (>= 2.1.1)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
+    sigdump (0.2.2)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    sneakers (1.0.4)
+      bunny (~> 1.7.0)
+      serverengine (~> 1.5.5)
+      thor
+      thread (~> 0.1.7)
+    sprockets (3.0.2)
+      rack (~> 1.0)
+    sqlite3 (1.3.10)
+    stackprof (0.2.7)
+    sucker_punch (1.3.2)
+      celluloid (~> 0.16.0)
+    thor (0.19.1)
+    thread (0.1.7)
+    thread_safe (0.3.5)
+    tilt (1.4.1)
+    timers (4.0.1)
+      hitimes
+    turbolinks (2.5.3)
+      coffee-rails
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (2.7.0)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
+    w3c_validators (1.2)
+      json
+      nokogiri
+
+PLATFORMS
+  ruby
+  x64-mingw32
+  x86-mingw32
+
+DEPENDENCIES
+  activerecord-jdbcmysql-adapter (>= 1.3.0)
+  activerecord-jdbcpostgresql-adapter (>= 1.3.0)
+  activerecord-jdbcsqlite3-adapter (>= 1.3.0)
+  arel!
+  backburner
+  bcrypt (~> 3.1.10)
+  benchmark-ips
+  byebug
+  coffee-rails (~> 4.1.0)
+  dalli (>= 2.2.1)
+  delayed_job
+  delayed_job_active_record
+  globalid!
+  jquery-rails!
+  json
+  kindlerb (= 0.1.1)
+  mail!
+  minitest (< 5.3.4)
+  mocha (~> 0.14)
+  mysql (>= 2.9.0)
+  mysql2 (>= 0.3.18)
+  nokogiri (>= 1.4.5)
+  pg (>= 0.18.0)
+  psych (~> 2.0)
+  qu-rails!
+  qu-redis
+  que
+  queue_classic
+  racc (>= 1.4.6)
+  rack-cache (~> 1.2)
+  rails!
+  rake (>= 10.3)
+  redcarpet (~> 3.2.3)
+  resque
+  resque-scheduler
+  sdoc (~> 0.4.0)
+  sequel
+  sidekiq
+  sneakers
+  sprockets (~> 3.0.0.rc.1)
+  sprockets-rails!
+  sqlite3 (~> 1.3.6)
+  stackprof
+  sucker_punch
+  turbolinks
+  uglifier (>= 1.3.0)
+  w3c_validators
+
+BUNDLED WITH
+   1.10.5

--- a/spec/fixtures/rails-gemfile.lock
+++ b/spec/fixtures/rails-gemfile.lock
@@ -1,0 +1,319 @@
+GIT
+  remote: git://github.com/bkeepers/qu.git
+  revision: d098e2657c92e89a6413bebd9c033930759c061f
+  branch: master
+  specs:
+    qu (0.2.0)
+    qu-rails (0.2.0)
+      qu (= 0.2.0)
+      railties (>= 3.2, < 5)
+    qu-redis (0.2.0)
+      qu (= 0.2.0)
+      redis-namespace
+
+GIT
+  remote: git://github.com/mikel/mail.git
+  revision: b159e0a542962fdd5e292a48cfffa560d7cf412e
+  specs:
+    mail (2.6.3.edge)
+      mime-types (>= 1.16, < 3)
+
+GIT
+  remote: git://github.com/rails/arel.git
+  revision: aac9da257f291ad8d2d4f914528881c240848bb2
+  branch: master
+  specs:
+    arel (7.0.0.alpha)
+
+GIT
+  remote: git://github.com/rails/globalid.git
+  revision: 4df66fb9e9f0c832d29119aa8bc30be55a614b71
+  specs:
+    globalid (0.3.5)
+      activesupport (>= 4.1.0)
+
+GIT
+  remote: git://github.com/rails/jquery-rails.git
+  revision: 272abdd319bb3381b23182b928b25320590096b0
+  branch: master
+  specs:
+    jquery-rails (4.0.3)
+      rails-dom-testing (~> 1.0)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+
+GIT
+  remote: git://github.com/rails/sprockets-rails.git
+  revision: 85b89c44ad40af3056899808475e6e4bf65c1f5a
+  branch: master
+  specs:
+    sprockets-rails (3.0.0.beta1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0, < 4.0)
+
+PATH
+  remote: .
+  specs:
+    actionmailer (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      rack (~> 1.6)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activejob (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      globalid (>= 0.3.0)
+    activemodel (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      builder (~> 3.1)
+    activerecord (5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      arel (= 7.0.0.alpha)
+    activesupport (5.0.0.alpha)
+      concurrent-ruby (~> 0.9.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    rails (5.0.0.alpha)
+      actionmailer (= 5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activerecord (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.0.alpha)
+      sprockets-rails
+    railties (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    amq-protocol (1.9.2)
+    backburner (0.4.6)
+      beaneater (~> 0.3.1)
+      dante (~> 0.1.5)
+    bcrypt (3.1.10)
+    bcrypt (3.1.10-x64-mingw32)
+    bcrypt (3.1.10-x86-mingw32)
+    beaneater (0.3.3)
+    benchmark-ips (2.1.1)
+    builder (3.2.2)
+    bunny (1.7.0)
+      amq-protocol (>= 1.9.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    coffee-rails (4.1.0)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 5.0)
+    coffee-script (2.3.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.0)
+    columnize (0.9.0)
+    concurrent-ruby (0.9.0)
+    connection_pool (2.1.1)
+    dalli (2.7.2)
+    dante (0.1.5)
+    delayed_job (4.0.6)
+      activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
+    erubis (2.7.0)
+    execjs (2.3.0)
+    hitimes (1.2.2)
+    hitimes (1.2.2-x86-mingw32)
+    i18n (0.7.0)
+    json (1.8.2)
+    kindlerb (0.1.1)
+      mustache
+      nokogiri
+    loofah (2.0.1)
+      nokogiri (>= 1.5.9)
+    metaclass (0.0.4)
+    method_source (0.8.2)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
+    minitest (5.3.3)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    mono_logger (1.1.0)
+    multi_json (1.11.0)
+    mustache (1.0.0)
+    mysql (2.9.1)
+    mysql2 (0.3.18)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x64-mingw32)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x86-mingw32)
+      mini_portile (~> 0.6.0)
+    pg (0.18.1)
+    psych (2.0.13)
+    que (0.9.2)
+    queue_classic (3.1.0)
+      pg (>= 0.17, < 0.19)
+    racc (1.4.12)
+    rack (1.6.0)
+    rack-cache (1.2)
+      rack (>= 0.4)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.6)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6.0)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.2)
+      loofah (~> 2.0)
+    rake (10.4.2)
+    rdoc (4.2.0)
+    redcarpet (3.2.3)
+    redis (3.2.1)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.25.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    resque-scheduler (4.0.0)
+      mono_logger (~> 1.0)
+      redis (~> 3.0)
+      resque (~> 1.25)
+      rufus-scheduler (~> 3.0)
+    rufus-scheduler (3.0.9)
+      tzinfo
+    sdoc (0.4.1)
+      json (~> 1.7, >= 1.7.7)
+      rdoc (~> 4.0)
+    sequel (4.19.0)
+    serverengine (1.5.10)
+      sigdump (~> 0.2.2)
+    sidekiq (3.3.2)
+      celluloid (>= 0.16.0)
+      connection_pool (>= 2.1.1)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
+    sigdump (0.2.2)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    sneakers (1.0.4)
+      bunny (~> 1.7.0)
+      serverengine (~> 1.5.5)
+      thor
+      thread (~> 0.1.7)
+    sprockets (3.0.2)
+      rack (~> 1.0)
+    sqlite3 (1.3.10)
+    stackprof (0.2.7)
+    sucker_punch (1.3.2)
+      celluloid (~> 0.16.0)
+    thor (0.19.1)
+    thread (0.1.7)
+    thread_safe (0.3.5)
+    tilt (1.4.1)
+    timers (4.0.1)
+      hitimes
+    turbolinks (2.5.3)
+      coffee-rails
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (2.7.0)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
+    w3c_validators (1.2)
+      json
+      nokogiri
+
+PLATFORMS
+  ruby
+  x64-mingw32
+  x86-mingw32
+
+DEPENDENCIES
+  activerecord-jdbcmysql-adapter (>= 1.3.0)
+  activerecord-jdbcpostgresql-adapter (>= 1.3.0)
+  activerecord-jdbcsqlite3-adapter (>= 1.3.0)
+  arel!
+  backburner
+  bcrypt (~> 3.1.10)
+  benchmark-ips
+  byebug
+  coffee-rails (~> 4.1.0)
+  dalli (>= 2.2.1)
+  delayed_job
+  delayed_job_active_record
+  globalid!
+  jquery-rails!
+  json
+  kindlerb (= 0.1.1)
+  mail!
+  minitest (< 5.3.4)
+  mocha (~> 0.14)
+  mysql (>= 2.9.0)
+  mysql2 (>= 0.3.18)
+  nokogiri (>= 1.4.5)
+  pg (>= 0.18.0)
+  psych (~> 2.0)
+  qu-rails!
+  qu-redis
+  que
+  queue_classic
+  racc (>= 1.4.6)
+  rack-cache (~> 1.2)
+  rails!
+  rake (>= 10.3)
+  redcarpet (~> 3.2.3)
+  resque
+  resque-scheduler
+  sdoc (~> 0.4.0)
+  sequel
+  sidekiq
+  sneakers
+  sprockets (~> 3.0.0.rc.1)
+  sprockets-rails!
+  sqlite3 (~> 1.3.6)
+  stackprof
+  sucker_punch
+  turbolinks
+  uglifier (>= 1.3.0)
+  w3c_validators
+
+BUNDLED WITH
+   1.10.5

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -41,7 +41,7 @@ describe Scanner do
 
       it "should ignore the specified advisories" do
         ids = subject.map { |result| result.advisory.id }
-        
+
         expect(ids).not_to include('OSVDB-89026')
       end
     end
@@ -69,6 +69,56 @@ describe Scanner do
 
     it "should print nothing when everything is fine" do
       expect(subject).to be_empty
+    end
+  end
+
+  describe "initialization with paths" do
+    let(:scanner) { described_class.new(*args) }
+    let(:expected_lockfile_contents) { File.read(expected_lockfile_path) }
+
+    context "when initialized without a root" do
+      let(:args) { [] }
+      let(:expected_lockfile_path) { File.expand_path("../../Gemfile.lock", __FILE__) }
+      before do
+        allow(Dir).to receive(:pwd).and_return(File.expand_path("../..", __FILE__))
+      end
+
+      it "defaults to a Gemfile.lock in the cwd" do
+        expect(Bundler::LockfileParser).to receive(:new).with(expected_lockfile_contents)
+        scanner
+      end
+
+      it "sets the root to the cwd" do
+        expect(scanner.root).to eq Dir.pwd
+      end
+    end
+
+    context "when initialized with a directory" do
+      let(:args) { [File.expand_path("../fixtures", __FILE__)] }
+      let(:expected_lockfile_path) { File.expand_path("../fixtures/Gemfile.lock", __FILE__) }
+
+      it "uses a Gemfile.lock in the supplied directory" do
+        expect(Bundler::LockfileParser).to receive(:new).with(expected_lockfile_contents)
+        scanner
+      end
+
+      it "sets the root to the supplied directory" do
+        expect(scanner.root).to eq File.expand_path("../fixtures", __FILE__)
+      end
+    end
+
+    context "when initialized with a file" do
+      let(:args) { [File.expand_path("../fixtures/rails-gemfile.lock", __FILE__)] }
+      let(:expected_lockfile_path) { File.expand_path("../fixtures/rails-gemfile.lock", __FILE__) }
+
+      it "uses the supplied filename" do
+        expect(Bundler::LockfileParser).to receive(:new).with(expected_lockfile_contents)
+        scanner
+      end
+
+      it "sets the root to the directory of the supplied file" do
+        expect(scanner.root).to eq File.expand_path("../fixtures", __FILE__)
+      end
     end
   end
 end


### PR DESCRIPTION
It should be possible to specify a Lockfile directly, rather than
assuming it’s in the current drectory and named `Gemfile.lock`