### PR TITLE
Allow insecure gem source if it lives on a private network.

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -107,6 +107,7 @@ module Bundler
           when Source::Rubygems
             source.remotes.each do |uri|
               if uri.scheme == 'http'
+                next if internal_host?(uri.to_s)
                 yield InsecureSource.new(uri.to_s)
               end
             end


### PR DESCRIPTION
Like having a git:// route on a local network, having an insecure route to a gem server should be allowed. In our case we're running gem-in-a-box.