### PR TITLE
Add --quiet as a command line option for update

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -33,9 +33,10 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
+      method_option :quiet, :type => :boolean, :aliases => '-q', default: false
 
       def check
-        update if options[:update]
+        update(options[:quiet]) if options[:update]
 
         scanner    = Scanner.new
         vulnerable = false
@@ -60,10 +61,10 @@ module Bundler
       end
 
       desc 'update', 'Updates the ruby-advisory-db'
-      def update
+      def update(quiet = false)
         say "Updating ruby-advisory-db ..."
 
-        Database.update!
+        Database.update!(quiet)
         puts "ruby-advisory-db: #{Database.new.size} advisories"
       end
 

--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -90,13 +90,17 @@ module Bundler
       #
       # @since 0.3.0
       #
-      def self.update!
+      def self.update!(quiet = false)
         if File.directory?(USER_PATH)
           Dir.chdir(USER_PATH) do
-            system 'git', 'pull', 'origin', 'master'
+            cmd = ['git', 'pull', 'origin', 'master']
+            cmd << '--quiet' if quiet
+            system *cmd
           end
         else
-          system 'git', 'clone', URL, USER_PATH
+          cmd = ['git', 'clone', URL, USER_PATH]
+          cmd << '--quiet' if quiet
+          system *cmd
         end
       end
 

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -49,6 +49,20 @@ describe Bundler::Audit::Database do
       Bundler::Audit::Database.update!
       expect(File.directory?(mocked_user_path)).to be true
     end
+
+    it "should pass the quiet command through" do
+      expect(Bundler::Audit::Database).
+        to receive(:system).
+        with('git', 'clone', Bundler::Audit::Database::VENDORED_PATH, mocked_user_path, '--quiet').
+        and_call_original
+      Bundler::Audit::Database.update!(true)
+
+      expect(Bundler::Audit::Database).
+        to receive(:system).
+        with('git', 'pull', 'origin', 'master', '--quiet').
+        and_call_original
+      Bundler::Audit::Database.update!(true)
+    end
   end
 
   describe "#initialize" do


### PR DESCRIPTION
Fixes #78, simply pass through the command line option --quiet to git commands.
