### PR TITLE
Include an ignore-insecure-sources flag

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -41,13 +41,12 @@ module Bundler
         scanner    = Scanner.new
         vulnerable = false
 
-        scanner.scan(:ignore => options.ignore,
-                     :ignore_insecure_sources => options.ignore_insecure_sources
-                    ) do |result|
+        scanner.scan(:ignore => options.ignore) do |result|
           vulnerable = true
 
           case result
           when Scanner::InsecureSource
+            vulnerable = false if options[:ignore_insecure_sources]
             print_warning "Insecure Source URI found: #{result.source}"
           when Scanner::UnpatchedGem
             print_advisory result.gem, result.advisory

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -32,6 +32,7 @@ module Bundler
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
+      method_option :ignore_insecure_sources, :type => :boolean, :aliases => '-s'
       method_option :update, :type => :boolean, :aliases => '-u'
 
       def check
@@ -40,7 +41,9 @@ module Bundler
         scanner    = Scanner.new
         vulnerable = false
 
-        scanner.scan(:ignore => options.ignore) do |result|
+        scanner.scan(:ignore => options.ignore,
+                     :ignore_insecure_sources => options.ignore_insecure_sources
+                    ) do |result|
           vulnerable = true
 
           case result

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -68,7 +68,7 @@ module Bundler
         ignore = Set[]
         ignore += options[:ignore] if options[:ignore]
 
-        scan_sources(options,&block) unless options[:ignore_insecure_sources]
+        scan_sources(options,&block)
         scan_specs(options,&block)
 
         return self

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -68,7 +68,7 @@ module Bundler
         ignore = Set[]
         ignore += options[:ignore] if options[:ignore]
 
-        scan_sources(options,&block)
+        scan_sources(options,&block) unless options[:ignore_insecure_sources]
         scan_specs(options,&block)
 
         return self


### PR DESCRIPTION
As mentioned here rubysec/bundler-audit#106

Currently, warnings about insecure sources - such as external git or http URIs - marks the lockfile as vulnerable. This leads to the gem exiting with code 1, effectively raising an error in the CI build process.

These warnings are entirely valid, but there should be a way of ignoring them.