### PR TITLE
Move file reading responsibility to the CLI

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,7 +34,8 @@ module Bundler
       method_option :ignore, :type => :array, :aliases => '-i'
 
       def check
-        scanner    = Scanner.new
+        root = File.expand_path(Dir.pwd)
+        scanner = Scanner.new(File.read(File.join(root, 'Gemfile.lock')))
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -22,9 +22,6 @@ module Bundler
       # @return [Database]
       attr_reader :database
 
-      # Project root directory
-      attr_reader :root
-
       # The parsed `Gemfile.lock` from the project
       #
       # @return [Bundler::LockfileParser]
@@ -33,15 +30,12 @@ module Bundler
       #
       # Initializes a scanner.
       #
-      # @param [String] root
+      # @param [String] lockfile_content
       #   The path to the project root.
       #
-      def initialize(root=Dir.pwd)
-        @root     = File.expand_path(root)
+      def initialize(lockfile_content)
         @database = Database.new
-        @lockfile = LockfileParser.new(
-          File.read(File.join(@root,'Gemfile.lock'))
-        )
+        @lockfile = LockfileParser.new(lockfile_content)
       end
 
       #


### PR DESCRIPTION
This means `Scanner` is a simple wrapper for `LockfileParser` and accepts
the same arguments (content in the form of a string, not a directory path).

This also means that `Scanner` is able to be called with content from
anywhere (for example, github's content API) instead of a hardcoded file
path and makes it more useful as a library other projects can depend on.