### PR TITLE
Support checking for newer gems.locked in addition to Gemfile.lock

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -39,8 +39,15 @@ module Bundler
       def initialize(root=Dir.pwd)
         @root     = File.expand_path(root)
         @database = Database.new
+
+        @file = if File.exists? File.join(@root,'Gemfile.lock')
+          File.join(@root,'Gemfile.lock')
+        elsif File.exists? File.join(@root,'gems.locked')
+          File.join(@root,'gems.locked')
+        end
+
         @lockfile = LockfileParser.new(
-          File.read(File.join(@root,'Gemfile.lock'))
+          File.read(@file)
         )
       end
 


### PR DESCRIPTION
Its just for discussion cause i didn't get the tests running. "gems.locked" is supported since Bundler 1.8.0 and will be default in 2.0 (as far as i know).
