### PR TITLE
README: update before check

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Update the [ruby-advisory-db] that `bundle-audit` uses:
 
 Update the [ruby-advisory-db] and check `Gemfile.lock` (useful for CI runs):
 
-    $ bundle-audit check --update
+    $ bundle-audit update && bundle-audit check
 
 Ignore specific advisories:
 


### PR DESCRIPTION
From running version 0.4.0 locally, the `bundle-audit update --check` command failed, so suggesting this update to the README.
