### PR TITLE
Audit ruby and gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,5 +53,5 @@ task :test    => :spec
 task :default => :spec
 
 require 'yard'
-YARD::Rake::YardocTask.new
+YARD::Rake::YardocTask.new  
 task :doc => :yard

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ namespace :db do
       sh 'git', 'pull', 'origin', 'master'
 
       File.open('../ruby-advisory-db.ts','w') do |file|
-        file.write Time.parse(`git log --pretty="%cd" -1`).utc
+        file.write Time.parse(`git log --date=iso8601 --pretty="%cd" -1`).utc
       end
     end
 
@@ -53,5 +53,5 @@ task :test    => :spec
 task :default => :spec
 
 require 'yard'
-YARD::Rake::YardocTask.new  
+YARD::Rake::YardocTask.new
 task :doc => :yard

--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -150,17 +150,17 @@ module Bundler
       end
 
       #
-      # Verifies whether the gem is effected by any advisories.
+      # Verifies whether the gem is affected by any advisories.
       #
       # @param [Gem::Specification] gem
       #   The gem to verify.
       #
       # @yield [advisory]
-      #   If a block is given, it will be passed advisories that effect
+      #   If a block is given, it will be passed advisories that affect
       #   the gem.
       #
       # @yieldparam [Advisory] advisory
-      #   An advisory that effects the specific version of the gem.
+      #   An advisory that affects the specific version of the gem.
       #
       # @return [Enumerator]
       #   If no block is given, an Enumerator will be returned.
@@ -170,17 +170,17 @@ module Bundler
       end
 
       #
-      # Verifies whether the Ruby is effected by any advisories.
+      # Verifies whether the Ruby is affected by any advisories.
       #
       # @param [Bundler::Audit::Scanner::Version] ruby
       #   The Ruby engine and version to verify.
       #
       # @yield [advisory]
-      #   If a block is given, it will be passed advisories that effect
+      #   If a block is given, it will be passed advisories that affect
       #   the Ruby.
       #
       # @yieldparam [Advisory] advisory
-      #   An advisory that effects the specific version of the Ruby.
+      #   An advisory that affects the specific version of the Ruby.
       #
       # @return [Enumerator]
       #   If no block is given, an Enumerator will be returned.
@@ -192,17 +192,17 @@ module Bundler
       end
 
       #
-      # Verifies whether the library is effected by any advisories.
+      # Verifies whether the library is affected by any advisories.
       #
       # @param [Bundler::Audit::Scanner::Version] library
       #   The library to verify.
       #
       # @yield [advisory]
-      #   If a block is given, it will be passed advisories that effect
+      #   If a block is given, it will be passed advisories that affect
       #   the Ruby.
       #
       # @yieldparam [Advisory] advisory
-      #   An advisory that effects the specific version of the Ruby.
+      #   An advisory that affects the specific version of the Ruby.
       #
       # @return [Enumerator]
       #   If no block is given, an Enumerator will be returned.
@@ -246,7 +246,7 @@ module Bundler
       protected
 
       #
-      # Verifies whether the object is effected by any advisories.
+      # Verifies whether the object is affected by any advisories.
       #
       # @param [Class] object
       #   The object to verify. This should be a class with name and version
@@ -256,11 +256,11 @@ module Bundler
       #   The advisory type; one of gems, libraries, or rubies.
       #
       # @yield [advisory]
-      #   If a block is given, it will be passed advisories that effect
+      #   If a block is given, it will be passed advisories that affect
       #   the gem.
       #
       # @yieldparam [Advisory] advisory
-      #   An advisory that effects the specific version of the gem.
+      #   An advisory that affects the specific version of the gem.
       #
       # @return [Enumerator]
       #   If no block is given, an Enumerator will be returned.

--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -129,6 +129,9 @@ module Bundler
       # @param [String] name
       #   The gem name to lookup.
       #
+      # @param [String] type
+      #   The advisory type; one of gems, libraries, or rubies.
+      #
       # @yield [advisory]
       #   If a block is given, each advisory for the given gem will be yielded.
       #
@@ -138,10 +141,10 @@ module Bundler
       # @return [Enumerator]
       #   If no block is given, an Enumerator will be returned.
       #
-      def advisories_for(name)
-        return enum_for(__method__,name) unless block_given?
+      def advisories_for(name,type='gems')
+        return enum_for(__method__,name,type) unless block_given?
 
-        each_advisory_path_for(name) do |path|
+        each_advisory_path_for(name,type) do |path|
           yield Advisory.load(path)
         end
       end
@@ -162,14 +165,52 @@ module Bundler
       # @return [Enumerator]
       #   If no block is given, an Enumerator will be returned.
       #
-      def check_gem(gem)
-        return enum_for(__method__,gem) unless block_given?
+      def check_gem(gem,&block)
+        check(gem,'gems',&block)
+      end
 
-        advisories_for(gem.name) do |advisory|
-          if advisory.vulnerable?(gem.version)
-            yield advisory
-          end
-        end
+      #
+      # Verifies whether the Ruby is effected by any advisories.
+      #
+      # @param [Bundler::Audit::Scanner::Version] ruby
+      #   The Ruby engine and version to verify.
+      #
+      # @yield [advisory]
+      #   If a block is given, it will be passed advisories that effect
+      #   the Ruby.
+      #
+      # @yieldparam [Advisory] advisory
+      #   An advisory that effects the specific version of the Ruby.
+      #
+      # @return [Enumerator]
+      #   If no block is given, an Enumerator will be returned.
+      #
+      # @since 0.5.0
+      #
+      def check_ruby(ruby,&block)
+        check(ruby,'rubies',&block)
+      end
+
+      #
+      # Verifies whether the library is effected by any advisories.
+      #
+      # @param [Bundler::Audit::Scanner::Version] library
+      #   The library to verify.
+      #
+      # @yield [advisory]
+      #   If a block is given, it will be passed advisories that effect
+      #   the Ruby.
+      #
+      # @yieldparam [Advisory] advisory
+      #   An advisory that effects the specific version of the Ruby.
+      #
+      # @return [Enumerator]
+      #   If no block is given, an Enumerator will be returned.
+      #
+      # @since 0.5.0
+      #
+      def check_library(library,&block)
+        check(library,'libraries',&block)
       end
 
       #
@@ -205,6 +246,38 @@ module Bundler
       protected
 
       #
+      # Verifies whether the object is effected by any advisories.
+      #
+      # @param [Class] object
+      #   The object to verify. This should be a class with name and version
+      #   attributes.
+      #
+      # @param [String] type
+      #   The advisory type; one of gems, libraries, or rubies.
+      #
+      # @yield [advisory]
+      #   If a block is given, it will be passed advisories that effect
+      #   the gem.
+      #
+      # @yieldparam [Advisory] advisory
+      #   An advisory that effects the specific version of the gem.
+      #
+      # @return [Enumerator]
+      #   If no block is given, an Enumerator will be returned.
+      #
+      # @since 0.5.0
+      #
+      def check(object,type='gems')
+        return enum_for(__method__,object,type) unless block_given?
+
+        advisories_for(object.name,type) do |advisory|
+          if advisory.vulnerable?(object.version)
+            yield advisory
+          end
+        end
+      end
+
+      #
       # Enumerates over every advisory path in the database.
       #
       # @yield [path]
@@ -214,7 +287,7 @@ module Bundler
       #   A path to an advisory `.yml` file.
       #
       def each_advisory_path(&block)
-        Dir.glob(File.join(@path,'gems','*','*.yml'),&block)
+        Dir.glob(File.join(@path,'{gems,libraries,rubies}','*','*.yml'),&block)
       end
 
       #
@@ -223,14 +296,17 @@ module Bundler
       # @param [String] name
       #   The gem of the gem.
       #
+      # @param [String] type
+      #   The advisory type; one of gems, libraries, or rubies.
+      #
       # @yield [path]
       #   The given block will be passed each advisory path.
       #
       # @yieldparam [String] path
       #   A path to an advisory `.yml` file.
       #
-      def each_advisory_path_for(name,&block)
-        Dir.glob(File.join(@path,'gems',name,'*.yml'),&block)
+      def each_advisory_path_for(name,type='gems',&block)
+        Dir.glob(File.join(@path,type,name,'*.yml'),&block)
       end
 
     end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -89,7 +89,7 @@ describe Bundler::Audit::Database do
     end
 
     context "when given a block" do
-      it "should yield every advisory effecting the gem" do
+      it "should yield every advisory affecting the gem" do
         advisories = []
 
         subject.check_gem(gem) do |advisory|
@@ -116,7 +116,7 @@ describe Bundler::Audit::Database do
     let(:library) { Bundler::Audit::Scanner::Version.new('rubygems','2.4.5') }
 
     context "when given a block" do
-      it "should yield every advisory effecting the library" do
+      it "should yield every advisory affecting the library" do
         advisories = []
 
         subject.check_library(library) do |advisory|
@@ -143,7 +143,7 @@ describe Bundler::Audit::Database do
     let(:ruby) { Bundler::Audit::Scanner::Version.new('ruby','2.2.1') }
 
     context "when given a block" do
-      it "should yield every advisory effecting the Ruby version" do
+      it "should yield every advisory affecting the Ruby version" do
         advisories = []
 
         subject.check_ruby(ruby) do |advisory|

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -3,8 +3,14 @@ require 'spec_helper'
 describe "CLI" do
   include Helpers
 
+  # The matrix build includes versions of Ruby with advisories. Always ignore
+  # them.
+  let(:ignore) do
+    '-i CVE-2014-2525 CVE-2014-3916 CVE-2014-4975 CVE-2015-1855 CVE-2015-3900 CVE-2015-4020'
+  end
+
   let(:command) do
-    File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundle-audit'))
+    File.expand_path(File.join(File.dirname(__FILE__),'..','bin',"bundle-audit #{ignore}"))
   end
 
   context "when auditing a bundle with unpatched gems" do
@@ -38,7 +44,7 @@ Solution: upgrade to ((~>|=>) \d+.\d+.\d+, )*(~>|=>) \d+.\d+.\d+[\s\n]*?)+/
     let(:directory) { File.join('spec','bundle',bundle) }
 
     let(:command) do
-      File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundle-audit -i OSVDB-89026'))
+      File.expand_path(File.join(File.dirname(__FILE__),'..','bin',"bundle-audit #{ignore} OSVDB-89026"))
     end
 
     subject do

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 require 'bundler/audit/scanner'
 
 describe Scanner do
+  # The matrix build includes versions of Ruby with advisories. Stub to
+  # versions without.
+  before(:each) do
+    stub_const('RUBY_VERSION', '2.2.3')
+    stub_const('RUBY_ENGINE', 'ruby')
+    stub_const('RUBY_PATCHLEVEL', 173)
+    allow_any_instance_of(Bundler::Audit::Scanner)
+      .to receive(:rubygems_version).and_return('2.4.8')
+  end
+
   describe "#scan" do
     let(:bundle)    { 'unpatched_gems' }
     let(:directory) { File.join('spec','bundle',bundle) }
@@ -19,6 +29,77 @@ describe Scanner do
     context "when not called with a block" do
       it "should return an Enumerator" do
         expect(subject.scan).to be_kind_of(Enumerable)
+      end
+    end
+  end
+
+  context "when auditing an unpatched Ruby" do
+    let(:bundle)    { 'secure' }
+    let(:directory) { File.join('spec','bundle',bundle) }
+    let(:scanner)   { described_class.new(directory)    }
+
+    subject { scanner.scan.to_a }
+
+    before(:each) do
+      stub_const('RUBY_VERSION', '2.2.1')
+      stub_const('RUBY_ENGINE', 'ruby')
+      stub_const('RUBY_PATCHLEVEL', 85)
+    end
+
+    it "should match an unpatched Ruby to its advisories" do
+      expect(subject.all? { |result|
+        result.advisory.vulnerable?(result.gem.version)
+      }).to be_truthy
+      expect(subject.map { |r| r.advisory.id }).to include("OSVDB-120541")
+    end
+
+    it "respects patch level" do
+      stub_const('RUBY_VERSION', '1.9.3')
+      stub_const('RUBY_PATCHLEVEL', 392)
+      expect(subject.map { |r| r.advisory.id }).to include("OSVDB-113747")
+    end
+
+    it "handles preview versions" do
+      stub_const('RUBY_VERSION', '2.1.0')
+      stub_const('RUBY_PATCHLEVEL', -1)
+      allow_any_instance_of(Bundler::Audit::Scanner)
+        .to receive(:ruby_version).and_return('2.1.0.dev')
+      expect(subject.map { |r| r.advisory.id }).to include("OSVDB-100113")
+    end
+
+    context "when the :ignore option is given" do
+      subject { scanner.scan(:ignore => ['OSVDB-120541']) }
+
+      it "should ignore the specified advisories" do
+        expect(subject.map { |r| r.advisory.id }).not_to include('OSVDB-120541')
+      end
+    end
+  end
+
+  context "when auditing an unpatched RubyGems" do
+    let(:bundle)    { 'secure' }
+    let(:directory) { File.join('spec','bundle',bundle) }
+    let(:scanner)   { described_class.new(directory)    }
+
+    subject { scanner.scan.to_a }
+
+    before(:each) do
+      allow_any_instance_of(Bundler::Audit::Scanner)
+        .to receive(:rubygems_version).and_return('2.4.5')
+    end
+
+    it "should match an unpatched RubyGems to its advisories" do
+      expect(subject.all? { |result|
+        result.advisory.vulnerable?(result.gem.version)
+      }).to be_truthy
+      expect(subject.map { |r| r.advisory.id }).to include("CVE-2015-3900")
+    end
+
+    context "when the :ignore option is given" do
+      subject { scanner.scan(:ignore => ['CVE-2015-3900']) }
+
+      it "should ignore the specified advisories" do
+        expect(subject.map { |r| r.advisory.id }).not_to include('CVE-2015-3900')
       end
     end
   end


### PR DESCRIPTION
https://github.com/rubysec/ruby-advisory-db now includes security bulletins for Rubies and libraries (i.e., RubyGems). There is a need to audit Ruby and RubyGems, and `bundler-audit` is a great candidate for this functionality, since most of the necessary functionality is already implemented. This pull request adds support for auditing the current Ruby and RubyGems versions.

The Ruby version is determined via `RUBY_ENGINE`, `RUBY_VERSION`, and `RUBY_PATCHLEVEL`. The RubyGems version is determined by shelling out to `gem -v`. This won't address environments where bundler-audit is run using a different Ruby engine (e.g., when auditing a project in a different directory), but seems consistent with https://github.com/rubysec/ruby-advisory-db/pull/45#issuecomment-32545332.

I _think_ the patchlevel issues should be straightforward. `ruby-advisory-db` seems to have standardized on one of:
- `major.minor.bugfix`
- `major.minor.bugfix.patchlevel`
- `major.minor.bugfix.preview.patchlevel`

I tested an assortment of versions, and verified that things behave as expected for:
- 1.9.3-p286
- 1.9.3-p551
- 2.2.1
- 2.2.2
- 2.2.3
- jruby-9.0.3.0
- rbx-2.5.8

It gets a little tricky with pre-release versions, like 
- 2.1.0preview1
- 2.2.0preview2
- 2.2.0rc1
- jruby-master+graal-dev

In those cases, `RUBY_PATCHLEVEL` is `-1`, even in the case of 2.2.0preview2. Since `ruby-advisory-db` is representing these as `major.minor.bugfix.preview.patchlevel`, I've worked around this by shelling out, though that's less than ideal.

Adding test coverage required updating the `ruby-advisory-db` submodule. This revealed an interesting issue with git:

```
% git log --pretty="%cd" -1
2015-10-28 12:13:14 -0500
% git log --date=iso8601 --pretty="%cd" -1
2015-10-28 12:13:14 -0400
```

To address that, I updated the `rake db:update` task to be consistent with `Bundler::Audit::Databse.path`.

For new functions, I included `@since 0.5.0`, assuming that when this is released, it will be a minor version bump.
