### PR TITLE
add Advisory#pretty_id for outputting presentable id

### DIFF
--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -70,7 +70,7 @@ module Bundler
 
       #
       # The CVE identifier.
-      # 
+      #
       # @return [String, nil]
       #
       def cve_id
@@ -84,6 +84,15 @@ module Bundler
       #
       def osvdb_id
         "OSVDB-#{osvdb}" if osvdb
+      end
+
+      #
+      # Formatted identifier used for output
+      #
+      # @return [String, nil]
+      #
+      def pretty_id
+        cve_id || osvdb_id
       end
 
       #

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -93,12 +93,7 @@ module Bundler
         say gem.version
 
         say "Advisory: ", :red
-
-        if advisory.cve
-          say "CVE-#{advisory.cve}"
-        elsif advisory.osvdb
-          say advisory.osvdb
-        end
+        say advisory.pretty_id
 
         say "Criticality: ", :red
         case advisory.criticality

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -118,6 +118,35 @@ describe Bundler::Audit::Advisory do
     end
   end
 
+  describe "#pretty_id" do
+    let(:cve) { "2015-1234" }
+    let(:osvdb) { "123456" }
+
+    context "when CVE id is present" do
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cve = cve
+        end
+      end
+
+      it "should use the CVE id" do
+        expect(subject.pretty_id).to eq(subject.cve_id)
+      end
+    end
+
+    context "when OSVDB id is present" do
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.osvdb = osvdb
+        end
+      end
+
+      it "should use the CVE id" do
+        expect(subject.pretty_id).to eq(subject.osvdb_id)
+      end
+    end
+  end
+
   describe "#criticality" do
     context "when cvss_v2 is between 0.0 and 3.3" do
       subject do
@@ -204,7 +233,7 @@ describe Bundler::Audit::Advisory do
 
       context "when unaffected_versions is not empty" do
         subject { described_class.load(path) }
-     
+
         context "when passed a version that matches one unaffected version" do
           let(:version) { Gem::Version.new(an_unaffected_version) }
 


### PR DESCRIPTION
Currently, `bundle-audit` will show CVE ids with 'CVE-' prepended but not for OSVDB ids.

```
$ bundle-audit

Name: some_gem
Version: 0.0.100
Advisory: CVE-2100-12345
Criticality: Medium
...

Name: some_gem
Version: 0.0.100
Advisory: 12345
Criticality: Unknown
...
```

This PR adds `Advisory#pretty_id` for presentation so the CLI output is clearer for OSVDB ids.
