### PR TITLE
Include date in advisory object

### DIFF
--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -23,6 +23,7 @@ module Bundler
                                 :id,
                                 :url,
                                 :title,
+                                :date,
                                 :description,
                                 :cvss_v2,
                                 :cve,
@@ -59,6 +60,7 @@ module Bundler
           id,
           data['url'],
           data['title'],
+          data['date'],
           data['description'],
           data['cvss_v2'],
           data['cve'],
@@ -70,7 +72,7 @@ module Bundler
 
       #
       # The CVE identifier.
-      # 
+      #
       # @return [String, nil]
       #
       def cve_id

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -44,6 +44,11 @@ describe Bundler::Audit::Advisory do
       it { is_expected.to eq(data['title'])       }
     end
 
+    describe '#date' do
+      subject { super().date }
+      it { is_expected.to eq(data['date'])        }
+    end
+
     describe '#cvss_v2' do
       subject { super().cvss_v2 }
       it { is_expected.to eq(data['cvss_v2'])     }
@@ -204,7 +209,7 @@ describe Bundler::Audit::Advisory do
 
       context "when unaffected_versions is not empty" do
         subject { described_class.load(path) }
-     
+
         context "when passed a version that matches one unaffected version" do
           let(:version) { Gem::Version.new(an_unaffected_version) }
 


### PR DESCRIPTION
The yamls from [ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db) have `date` ([example](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/nokogiri/CVE-2015-1819.yml#L6)). Seems missing from advisory. This Pull Request adds `date` to `Advisory`.