### PR TITLE
Only try to do a git pull if ".git" exists

### DIFF
--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -91,7 +91,7 @@ module Bundler
       # @since 0.3.0
       #
       def self.update!
-        if File.directory?(USER_PATH)
+        if File.directory?(File.join(USER_PATH, ".git"))
           Dir.chdir(USER_PATH) do
             system 'git', 'pull', 'origin', 'master'
           end


### PR DESCRIPTION
This allow `update` to work if the directory already exists.