### PR TITLE
Add a new command `list`

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -83,6 +83,25 @@ module Bundler
         puts "#{File.basename($0)} #{VERSION} (advisories: #{database.size})"
       end
 
+      desc 'list', 'Processes a list of installed gems'
+      def list
+        db = Database.new
+        STDIN.each_line do |line|
+          name, version = unpack_version(line.chomp)
+          # Explicitly ignore anything with a version of "java"
+          next if version == "java"
+
+          spec = Gem::Specification.new do |s|
+            s.name = name
+            s.version = version
+          end
+
+          db.check_gem(spec) do |advisory|
+            print_advisory spec, advisory
+          end
+        end
+      end
+
       protected
 
       def say(message="", color=nil)
@@ -92,6 +111,12 @@ module Bundler
 
       def print_warning(message)
         say message, :yellow
+      end
+
+      def unpack_version(gem)
+        parts = gem.split("-")
+        version = parts.pop
+        [parts.join("-"), version]
       end
 
       def print_advisory(gem, advisory)

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -78,8 +78,8 @@ module Bundler
         puts "#{File.basename($0)} #{VERSION} (advisories: #{database.size})"
       end
 
-      desc 'list', 'Processes a list of installed gems'
-      def list
+      desc 'batch', 'Processes a list of installed gems from stdin'
+      def batch
         db = Database.new
         STDIN.each_line do |line|
           vulnerable = 0

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -97,8 +97,8 @@ module Bundler
             print_advisory spec, advisory
           end
 
-          warn_and_maybe_exit(vulnerable)
         end
+        warn_and_maybe_exit(vulnerable)
       end
 
       protected

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -82,7 +82,7 @@ module Bundler
       def batch
         db = Database.new
         STDIN.each_line do |line|
-          vulnerable = 0
+          vulnerable = false
           name, version = unpack_version(line.chomp)
           # Explicitly ignore anything with a version of "java"
           next if version == "java"
@@ -93,7 +93,7 @@ module Bundler
           end
 
           db.check_gem(spec) do |advisory|
-            vulnerable = 1
+            vulnerable = true
             print_advisory spec, advisory
           end
 

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -51,12 +51,7 @@ module Bundler
           end
         end
 
-        if vulnerable
-          say "Vulnerabilities found!", :red
-          exit 1
-        else
-          say "No vulnerabilities found", :green
-        end
+        warn_and_maybe_exit(vulnerable)
       end
 
       desc 'update', 'Updates the ruby-advisory-db'
@@ -87,6 +82,7 @@ module Bundler
       def list
         db = Database.new
         STDIN.each_line do |line|
+          vulnerable = 0
           name, version = unpack_version(line.chomp)
           # Explicitly ignore anything with a version of "java"
           next if version == "java"
@@ -97,8 +93,11 @@ module Bundler
           end
 
           db.check_gem(spec) do |advisory|
+            vulnerable = 1
             print_advisory spec, advisory
           end
+
+          warn_and_maybe_exit(vulnerable)
         end
       end
 
@@ -117,6 +116,15 @@ module Bundler
         parts = gem.split("-")
         version = parts.pop
         [parts.join("-"), version]
+      end
+
+      def warn_and_maybe_exit(vulnerable)
+        if vulnerable
+          say "Vulnerabilities found!", :red
+          exit 1
+        else
+          say "No vulnerabilities found", :green
+        end
       end
 
       def print_advisory(gem, advisory)


### PR DESCRIPTION
List is poorly named, but I couldn't come up with anything better
offhand. The usecase is something along the lines of:

        ls /opt/someapp/gems | bundler-audit list

For when you have a third party application with a bunch of bundled
gems, but the Gemfile and Gemfile.lock not included with the deployed
application.

Please feel free to propose a better name for the command!