### PR TITLE
Allow the user to specify an output filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Ignore specific advisories:
 Rake task:
 
 ```ruby
-require 'bundler/audit/task'
+require_relative 'lib/bundler/audit/task'
 Bundler::Audit::Task.new
 
 task default: 'bundle:audit'

--- a/README.md
+++ b/README.md
@@ -123,8 +123,20 @@ Write to an HTML file:
 Rake task:
 
 ```ruby
-require 'bundler/audit/task'
-Bundler::Audit::Task.new
+# Overriding the default task with one that accepts the output file
+# Can be invoked as: rake bundler:audit\[bundler-audit-report.html\]
+namespace :bundler do
+  desc 'Run bundler-audit'
+  task :audit, :output_files do |_t, args|
+    require 'bundler/audit/cli'
+
+    Bundler::Audit::CLI.start ['update']
+
+    files = args[:output_files].split(' ') if args[:output_files]
+    output_file_name = files.blank? ? 'bundler-audit-report.html' : files.first
+    Bundler::Audit::CLI.start ['check', "-o=#{output_file_name}"]
+  end
+end
 
 task default: 'bundle:audit'
 ```

--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ task default: 'bundle:audit'
 Rake task:
 
 ```ruby
+require_relative 'lib/bundler/audit/task'
+Bundler::Audit::Task.new
+
+task default: 'bundle:audit'
+```
+
+Rake task:
+
+```ruby
 # Overriding the default task with one that accepts the output file
 # Can be invoked as: rake bundler:audit\[bundler-audit-report.html\]
 namespace :bundler do

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Ignore specific advisories:
 Rake task:
 
 ```ruby
-require_relative 'lib/bundler/audit/task'
+require 'bundler/audit/task'
 Bundler::Audit::Task.new
 
 task default: 'bundle:audit'

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ task default: 'bundle:audit'
 Rake task:
 
 ```ruby
-require_relative 'lib/bundler/audit/task'
+require 'bundler/audit/task'
 Bundler::Audit::Task.new
 
 task default: 'bundle:audit'

--- a/README.md
+++ b/README.md
@@ -116,9 +116,14 @@ Ignore specific advisories:
 
     $ bundle-audit check --ignore OSVDB-108664
 
-Write to an HTML file:
+Rake task:
 
-    $ bundle-audit -o=tmp/audit.html
+```ruby
+require_relative 'lib/bundler/audit/task'
+Bundler::Audit::Task.new
+
+task default: 'bundle:audit'
+```
 
 Rake task:
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ end
 task default: 'bundle:audit'
 ```
 
+Rake task:
+
+```ruby
+require_relative 'lib/bundler/audit/task'
+Bundler::Audit::Task.new
+
+task default: 'bundle:audit'
+```
+
 ## Requirements
 
 * [Ruby] >= 1.9.3

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ Bundler::Audit::Task.new
 task default: 'bundle:audit'
 ```
 
+Rake task:
+
+```ruby
+require_relative 'lib/bundler/audit/task'
+Bundler::Audit::Task.new
+
+task default: 'bundle:audit'
+```
+
 ## Requirements
 
 * [Ruby] >= 1.9.3

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ task default: 'bundle:audit'
 Rake task:
 
 ```ruby
-require_relative 'lib/bundler/audit/task'
+require 'bundler/audit/task'
 Bundler::Audit::Task.new
 
 task default: 'bundle:audit'

--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ Bundler::Audit::Task.new
 task default: 'bundle:audit'
 ```
 
+Rake task:
+
+```ruby
+require_relative 'lib/bundler/audit/task'
+Bundler::Audit::Task.new
+
+task default: 'bundle:audit'
+```
+
 ## Requirements
 
 * [Ruby] >= 1.9.3

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ Bundler::Audit::Task.new
 task default: 'bundle:audit'
 ```
 
+Rake task:
+
+```ruby
+require_relative 'lib/bundler/audit/task'
+Bundler::Audit::Task.new
+
+task default: 'bundle:audit'
+```
+
 ## Requirements
 
 * [Ruby] >= 1.9.3

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ task default: 'bundle:audit'
 Rake task:
 
 ```ruby
-require_relative 'lib/bundler/audit/task'
+require 'bundler/audit/task'
 Bundler::Audit::Task.new
 
 task default: 'bundle:audit'

--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -69,6 +69,24 @@ module Bundler
       end
 
       #
+      # The CVE identifier.
+      # 
+      # @return [String, nil]
+      #
+      def cve_id
+        "CVE-#{cve}" if cve
+      end
+
+      #
+      # The OSVDB identifier.
+      #
+      # @return [String, nil]
+      #
+      def osvdb_id
+        "OSVDB-#{osvdb}" if osvdb
+      end
+
+      #
       # Determines how critical the vulnerability is.
       #
       # @return [:low, :medium, :high]

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -145,7 +145,8 @@ module Bundler
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
-            unless ignore.include?(advisory.id)
+            unless (ignore.include?(advisory.cve_id) ||
+                    ignore.include?(advisory.osvdb_id))
               yield UnpatchedGem.new(gem,advisory)
             end
           end

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -120,28 +120,33 @@ describe Bundler::Audit::Advisory do
 
   describe "#criticality" do
     context "when cvss_v2 is between 0.0 and 3.3" do
-      before {
-        @advisory = Advisory.new
-        @advisory.cvss_v2 = 3.3
-      }
-      it { expect(@advisory.criticality).to eq(:low) }
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v2 = 3.3
+        end
+      end
+
+      it { expect(subject.criticality).to eq(:low) }
     end
 
     context "when cvss_v2 is between 3.3 and 6.6" do
-      before {
-        @advisory = Advisory.new
-        @advisory.cvss_v2 = 6.6
-      }
-      it { expect(@advisory.criticality).to eq(:medium) }
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v2 = 6.6
+        end
+      end
 
+      it { expect(subject.criticality).to eq(:medium) }
     end
 
     context "when cvss_v2 is between 6.6 and 10.0" do
-     before {
-        @advisory = Advisory.new
-        @advisory.cvss_v2 = 10.0
-      }
-      it { expect(@advisory.criticality).to eq(:high) }
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v2 = 10.0
+        end
+      end
+
+      it { expect(subject.criticality).to eq(:high) }
     end
   end
 

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -78,6 +78,46 @@ describe Bundler::Audit::Advisory do
     end
   end
 
+  describe "#cve_id" do
+    let(:cve) { "2015-1234" }
+
+    subject do
+      described_class.new.tap do |advisory|
+        advisory.cve = cve
+      end
+    end
+
+    it "should prepend CVE- to the CVE id" do
+      expect(subject.cve_id).to be == "CVE-#{cve}"
+    end
+
+    context "when cve is nil" do
+      subject { described_class.new }
+
+      it { expect(subject.cve_id).to be_nil }
+    end
+  end
+
+  describe "#osvdb_id" do
+    let(:osvdb) { "123456" }
+
+    subject do
+      described_class.new.tap do |advisory|
+        advisory.osvdb = osvdb
+      end
+    end
+
+    it "should prepend OSVDB- to the OSVDB id" do
+      expect(subject.osvdb_id).to be == "OSVDB-#{osvdb}"
+    end
+
+    context "when cve is nil" do
+      subject { described_class.new }
+
+      it { expect(subject.osvdb_id).to be_nil }
+    end
+  end
+
   describe "#criticality" do
     context "when cvss_v2 is between 0.0 and 3.3" do
       before {


### PR DESCRIPTION
so that the html report can be captured in a custom location as needed. If no argument is specified, the report is generated with a default name.
