### PR TITLE
Tick version to resolve dependency issues.

### DIFF
--- a/lib/bundler/audit/version.rb
+++ b/lib/bundler/audit/version.rb
@@ -18,6 +18,6 @@
 module Bundler
   module Audit
     # bundler-audit version
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end


### PR DESCRIPTION
Version 0.4.0 was released back in June of 2015. Since then about 15
commits have been made. Even though many changes were made the version
number remained the same. This has cause some confusion as the version
0.4.0 listed on rubygems does not have features that the current version
of 0.4.0 has.