### PR TITLE
Add support for scan gems.locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Patch-level verification for [Bundler][bundler].
 
 ## Features
 
-* Checks for vulnerable versions of gems in `Gemfile.lock`.
+* Checks for vulnerable versions of gems in `Gemfile.lock` / `gems.locked`.
 * Checks for insecure gem sources (`http://`).
 * Allows ignoring certain advisories that have been manually worked around.
 * Prints advisory information.
@@ -21,7 +21,7 @@ Patch-level verification for [Bundler][bundler].
 
 ## Synopsis
 
-Audit a projects `Gemfile.lock`:
+Audit a project's `Gemfile.lock` / `gems.locked`:
 
     $ bundle-audit
     Name: actionpack
@@ -108,7 +108,7 @@ Update the [ruby-advisory-db] that `bundle-audit` uses:
      create mode 100644 gems/wicked/OSVDB-98270.yml
     ruby-advisory-db: 64 advisories
 
-Update the [ruby-advisory-db] and check `Gemfile.lock` (useful for CI runs):
+Update the [ruby-advisory-db] and check `Gemfile.lock` / `gems.locked` (useful for CI runs):
 
     $ bundle-audit check --update
 

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -29,7 +29,7 @@ module Bundler
       default_task :check
       map '--version' => :version
 
-      desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
+      desc 'check', 'Checks the lockfile for insecure dependencies'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'


### PR DESCRIPTION
This Pull Request adds support for scanning new lockfile (`gems.locked`), which Bundler [introduced in 1.8.0.pre](https://github.com/bundler/bundler/blob/2-0-dev/CHANGELOG.md#180pre-2015-01-26) from [bundler/bundler@0823e10](https://github.com/bundler/bundler/commit/0823e10). 
