### PR TITLE
Run as external Bundler command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Patch-level verification for [Bundler][bundler].
 
 Audit a project's `Gemfile.lock`:
 
-    $ bundle-audit
+    $ bundle audit
     Name: actionpack
     Version: 3.2.10
     Advisory: OSVDB-91452
@@ -82,9 +82,9 @@ Audit a project's `Gemfile.lock`:
 
     Unpatched versions found!
 
-Update the [ruby-advisory-db] that `bundle-audit` uses:
+Update the [ruby-advisory-db] that `bundle audit` uses:
 
-    $ bundle-audit update
+    $ bundle audit update
     Updating ruby-advisory-db ...
     remote: Counting objects: 44, done.
     remote: Compressing objects: 100% (24/24), done.
@@ -110,11 +110,11 @@ Update the [ruby-advisory-db] that `bundle-audit` uses:
 
 Update the [ruby-advisory-db] and check `Gemfile.lock` (useful for CI runs):
 
-    $ bundle-audit check --update
+    $ bundle audit check --update
 
 Ignore specific advisories:
 
-    $ bundle-audit check --ignore OSVDB-108664
+    $ bundle audit check --ignore OSVDB-108664
 
 Rake task:
 

--- a/bin/bundler-audit
+++ b/bin/bundler-audit
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+load File.expand_path('../bundle-audit', __FILE__)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -4,7 +4,7 @@ describe "CLI" do
   include Helpers
 
   let(:command) do
-    File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundle-audit'))
+    File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundler-audit'))
   end
 
   context "when auditing a bundle with unpatched gems" do
@@ -38,7 +38,7 @@ Solution: upgrade to ((~>|=>) \d+.\d+.\d+, )*(~>|=>) \d+.\d+.\d+[\s\n]*?)+/
     let(:directory) { File.join('spec','bundle',bundle) }
 
     let(:command) do
-      File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundle-audit -i OSVDB-89026'))
+      File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundler-audit -i OSVDB-89026'))
     end
 
     subject do


### PR DESCRIPTION
When a user runs `bundle COMMAND` and Bundler does not include COMMAND, it tries to run an executable named `bundler-COMMAND`.

This commit exploits this behavior and allows the user to run `bundle audit` to run bundler-audit.