### PR TITLE
Add --quiet option to `check` and `update` commands

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Added `--quiet` option to `check` and `update` commands.
+
 ### 0.5.0 / 2016-02-28
 
 * Added {Bundler::Audit::Task}.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ task default: 'bundle:audit'
 
     $ gem install bundler-audit
 
+## Contributing
+
+1. Clone the repo
+1. `git submodule update --init` # To populate data dir.
+1. `bundle exec rake`
+
 ## License
 
 Copyright (c) 2013-2016 Hal Brodigan (postmodern.mod3 at gmail.com)

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -30,6 +30,7 @@ module Bundler
       map '--version' => :version
 
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
+      method_option :quiet, :type => :boolean, :aliases => '-q'
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
@@ -55,17 +56,19 @@ module Bundler
           say "Vulnerabilities found!", :red
           exit 1
         else
-          say "No vulnerabilities found", :green
+          say("No vulnerabilities found", :green) unless options.quiet?
         end
       end
 
       desc 'update', 'Updates the ruby-advisory-db'
-      def update
-        say "Updating ruby-advisory-db ..."
+      method_option :quiet, :type => :boolean, :aliases => '-q'
 
-        case Database.update!
+      def update
+        say("Updating ruby-advisory-db ...") unless options.quiet?
+
+        case Database.update!(quiet: options.quiet?)
         when true
-          say "Updated ruby-advisory-db", :green
+          say("Updated ruby-advisory-db", :green) unless options.quiet?
         when false
           say "Failed updating ruby-advisory-db!", :red
           exit 1
@@ -73,7 +76,9 @@ module Bundler
           say "Skipping update", :yellow
         end
 
-        puts "ruby-advisory-db: #{Database.new.size} advisories"
+        unless options.quiet?
+          puts("ruby-advisory-db: #{Database.new.size} advisories")
+        end
       end
 
       desc 'version', 'Prints the bundler-audit version'

--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -82,6 +82,9 @@ module Bundler
       #
       # Updates the ruby-advisory-db.
       #
+      # @param [Boolean, quiet]
+      #   Specify whether `git` should be `--quiet`.
+      #
       # @return [Boolean, nil]
       #   Specifies whether the update was successful.
       #   A `nil` indicates no update was performed.
@@ -91,15 +94,22 @@ module Bundler
       #
       # @since 0.3.0
       #
-      def self.update!
+      def self.update!(options={})
+        raise "Invalid option(s)" unless (options.keys - [:quiet]).empty?
         if File.directory?(USER_PATH)
           if File.directory?(File.join(USER_PATH, ".git"))
             Dir.chdir(USER_PATH) do
-              system 'git', 'pull', 'origin', 'master'
+              command = %w(git pull)
+              command << '--quiet' if options[:quiet]
+              command << 'origin' << 'master'
+              system *command
             end
           end
         else
-          system 'git', 'clone', URL, USER_PATH
+          command = %w(git clone)
+          command << '--quiet' if options[:quiet]
+          command << URL << USER_PATH
+          system *command
         end
       end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2,43 +2,98 @@ require 'spec_helper'
 require 'bundler/audit/cli'
 
 describe Bundler::Audit::CLI do
+  describe "#update" do
+    context "not --quiet (the default)" do
+      context "when update succeeds" do
 
-  context "when update succeeds" do
+        before { expect(Bundler::Audit::Database).to receive(:update!).and_return(true) }
 
-    before { expect(Bundler::Audit::Database).to receive(:update!).and_return(true) }
-
-    it "prints updated message" do
-      expect { subject.update }.to output(/Updated ruby-advisory-db/).to_stdout
-    end
-
-    it "prints total advisory count" do
-      database = double
-      expect(database).to receive(:size).and_return(1234)
-      expect(Bundler::Audit::Database).to receive(:new).and_return(database)
-
-      expect { subject.update }.to output(/ruby-advisory-db: 1234 advisories/).to_stdout
-    end
-  end
-
-  context "when update fails" do
-
-    before { expect(Bundler::Audit::Database).to receive(:update!).and_return(false) }
-
-    it "prints failure message" do
-      expect do
-        begin
-          subject.update
-        rescue SystemExit
+        it "prints updated message" do
+          expect { subject.update }.to output(/Updated ruby-advisory-db/).to_stdout
         end
-      end.to output(/Failed updating ruby-advisory-db!/).to_stdout
-    end
 
-    it "exits with error status code" do
-      expect { subject.update }.to raise_error(SystemExit) do |error|
-        expect(error.success?).to eq(false)
-        expect(error.status).to eq(1)
+        it "prints total advisory count" do
+          database = double
+          expect(database).to receive(:size).and_return(1234)
+          expect(Bundler::Audit::Database).to receive(:new).and_return(database)
+
+          expect { subject.update }.to output(/ruby-advisory-db: 1234 advisories/).to_stdout
+        end
+      end
+
+      context "when update fails" do
+
+        before { expect(Bundler::Audit::Database).to receive(:update!).and_return(false) }
+
+        it "prints failure message" do
+          expect do
+            begin
+              subject.update
+            rescue SystemExit
+            end
+          end.to output(/Failed updating ruby-advisory-db!/).to_stdout
+        end
+
+        it "exits with error status code" do
+          expect {
+            # Capture output of `update` only to keep spec output clean.
+            # The test regarding specific output is above.
+            expect { subject.update }.to output.to_stdout
+          }.to raise_error(SystemExit) do |error|
+            expect(error.success?).to eq(false)
+            expect(error.status).to eq(1)
+          end
+        end
+
       end
     end
 
+    context "--quiet" do
+      before do
+        allow(subject).to receive(:options).and_return(double("Options", quiet?: true))
+      end
+
+      context "when update succeeds" do
+
+        before do
+          expect(Bundler::Audit::Database).to(
+            receive(:update!).with(quiet: true).and_return(true)
+          )
+        end
+
+        it "does not print any output" do
+          expect { subject.update }.to_not output.to_stdout
+        end
+      end
+
+      context "when update fails" do
+
+        before do
+          expect(Bundler::Audit::Database).to(
+            receive(:update!).with(quiet: true).and_return(false)
+          )
+        end
+
+        it "prints failure message" do
+          expect do
+            begin
+              subject.update
+            rescue SystemExit
+            end
+          end.to output(/Failed updating ruby-advisory-db!/).to_stdout
+        end
+
+        it "exits with error status code" do
+          expect {
+            # Capture output of `update` only to keep spec output clean.
+            # The test regarding specific output is above.
+            expect { subject.update }.to output.to_stdout
+          }.to raise_error(SystemExit) do |error|
+            expect(error.success?).to eq(false)
+            expect(error.status).to eq(1)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -15,7 +15,7 @@ describe Bundler::Audit::Database do
     end
 
     it "should prefer the user repo, iff it's as up to date, or more up to date than the vendored one" do
-      Bundler::Audit::Database.update!
+      Bundler::Audit::Database.update!(quiet: false)
 
       Dir.chdir(Bundler::Audit::Database::USER_PATH) do
         puts "Timestamp:"
@@ -36,17 +36,17 @@ describe Bundler::Audit::Database do
 
   describe "update!" do
     it "should create the USER_PATH path as needed" do
-      Bundler::Audit::Database.update!
+      Bundler::Audit::Database.update!(quiet: false)
       expect(File.directory?(mocked_user_path)).to be true
     end
 
     it "should create the repo, then update it given multple successive calls." do
       expect_update_to_clone_repo!
-      Bundler::Audit::Database.update!
+      Bundler::Audit::Database.update!(quiet: false)
       expect(File.directory?(mocked_user_path)).to be true
 
       expect_update_to_update_repo!
-      Bundler::Audit::Database.update!
+      Bundler::Audit::Database.update!(quiet: false)
       expect(File.directory?(mocked_user_path)).to be true
     end
   end


### PR DESCRIPTION
Hi Hal. This implements https://github.com/rubysec/bundler-audit/issues/164

I couldn't find development instructions, so I hope I'm adding tests in the right place, and following the project style. I get a few test failures locally that seem unrelated to my work, and I'm hoping they pass on CI.