### PR TITLE
Allow Gemfile path to be specified

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -33,11 +33,12 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
+      method_option :project_root, :type => :string, :aliases => '-p'
 
       def check
         update if options[:update]
 
-        scanner    = Scanner.new
+        scanner    = Scanner.new(options.fetch(:project_root, Dir.pwd))
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -36,7 +36,7 @@ module Bundler
       # @param [String] root
       #   The path to the project root.
       #
-      def initialize(root=Dir.pwd)
+      def initialize(root)
         @root     = File.expand_path(root)
         @database = Database.new
         @lockfile = LockfileParser.new(


### PR DESCRIPTION
This allows for bundler-audit to be run from a different directory.

I have a use case where I would like to run `bundler-audit` on several projects. Allowing the path of the project folder to be specified makes this easier without having to change directories.