### PR TITLE
Treat 127.0.0.0/8 and ::1/128 sources as secure

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -187,11 +187,15 @@ module Bundler
       #
       # @see https://tools.ietf.org/html/rfc1918#section-3
       # @see https://tools.ietf.org/html/rfc4193#section-8
+      # @see https://tools.ietf.org/html/rfc6890#section-2.2.2
+      # @see https://tools.ietf.org/html/rfc6890#section-2.2.3
       INTERNAL_SUBNETS = %w[
         10.0.0.0/8
         172.16.0.0/12
         192.168.0.0/16
         fc00::/7
+        127.0.0.0/8
+        ::1/128
       ].map(&IPAddr.method(:new))
 
       #


### PR DESCRIPTION
We use a local loopback address to serve our custom gems before vendorizing them. Yes, we could use a FS path, but that leads to conflicts across different developer machines.

PR #90 treats internal git/http hosts as secure. „internal“ roughly means „RFC1918 address“ there. I propose extending this definition to local loopback addresses.

Minimal example:

```sh
mkdir -p repo/gems
# fill repo/gems with *.gem files
gem generate_index --directory repo
cd repo
ruby -rwebrick -e'WEBrick::HTTPServer.new(BindAddress: "localhost", Port: 8808, DocumentRoot: Dir.pwd).start'
```

I also set the version number to `0.5.0.1`. Tell me, if you want me to remove that commit.

Thanks for sharing `bundler-audit`!
Alex