### PR TITLE
Check if the Gemfile.lock path exists before reading

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -41,10 +41,13 @@ module Bundler
       #
       def initialize(root=Dir.pwd,gemfile_lock='Gemfile.lock')
         @root     = File.expand_path(root)
+        gemfile_lock_path = File.join(@root,gemfile_lock)
+        unless File.file?(gem_file_lock_path)
+          puts "Unable to find the gem's Gemfile.lock file in #{@root}!"
+          exit 1
+        end
         @database = Database.new
-        @lockfile = LockfileParser.new(
-          File.read(File.join(@root,gemfile_lock))
-        )
+        @lockfile = LockfileParser.new(File.read(gem_file_lock_path))
       end
 
       #


### PR DESCRIPTION
Sometimes a project may not have a Gemfile.lock — and so in these cases
when bundler audit is ran in the working directory of a project then
the command will simply crash without providing a clean error as to why.

To clean this up, I’ve added a small check for the file’s existence;
and upon failure, a reason is printed to the screen as to why and then
a non-zero exit code is thrown to signify an error occurred.

I’m open to cleaning this up in a different way / maybe giving a
different error or something — but I figure’d this would work for me.