### PR TITLE
Support gems.locked

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -16,6 +16,7 @@
 #
 
 require 'bundler/audit/scanner'
+require 'bundler/audit/lockfile_loader'
 require 'bundler/audit/version'
 
 require 'thor'
@@ -38,8 +39,7 @@ module Bundler
       def check
         update if options[:update]
 
-        lockfile   = File.read(File.join(Dir.pwd, 'Gemfile.lock'))
-        scanner    = Scanner.new(lockfile)
+        scanner    = Scanner.new(LockfileLoader.new(Dir.pwd).contents)
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -38,7 +38,8 @@ module Bundler
       def check
         update if options[:update]
 
-        scanner    = Scanner.new
+        lockfile   = File.read(File.join(Dir.pwd, 'Gemfile.lock'))
+        scanner    = Scanner.new(lockfile)
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/lib/bundler/audit/lockfile_loader.rb
+++ b/lib/bundler/audit/lockfile_loader.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+module Bundler
+  module Audit
+    class LockfileLoader
+      # The project path used to find the lockfile.
+      #
+      # @return [String]
+      attr_reader :path
+
+      # Initializes a scanner.
+      #
+      # @param [String] path
+      #   The project path used to find the lockfile.
+      def initialize(path)
+        @path = path
+      end
+
+      # Seaches for the lockfile in the given path, and then returns its contents as a string.
+      #
+      # @return [String]
+      #   The string contents of the lockfile
+      def contents
+        self.class.lockfile_names.each do |lockfile_name|
+          filename = File.join(path, lockfile_name)
+          return File.read(filename) if File.exist?(filename)
+        end
+
+        raise StandardError, "Cannot find a lockfile named #{self.class.lockfile_names} in #{path}"
+      end
+
+      # Returns the ordered list of lockfiles to search, depending on the version of Bundler.
+      #
+      # @return [Array]
+      #   Possible lockfile names.
+      def self.lockfile_names
+        if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.8.0.pre'.freeze)
+          ["gems.locked", "Gemfile.lock"].freeze
+        else
+          ["Gemfile.lock"].freeze
+        end
+      end
+    end
+  end
+end
+

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -22,10 +22,7 @@ module Bundler
       # @return [Database]
       attr_reader :database
 
-      # Project root directory
-      attr_reader :root
-
-      # The parsed `Gemfile.lock` from the project
+      # The parsed lockfile from the project
       #
       # @return [Bundler::LockfileParser]
       attr_reader :lockfile
@@ -33,18 +30,12 @@ module Bundler
       #
       # Initializes a scanner.
       #
-      # @param [String] root
-      #   The path to the project root.
+      # @param [String] lockfile
+      #   Contents of the project lockfile.
       #
-      # @param [String] gemfile_lock
-      #   Alternative name for the `Gemfile.lock` file.
-      #
-      def initialize(root=Dir.pwd,gemfile_lock='Gemfile.lock')
-        @root     = File.expand_path(root)
+      def initialize(lockfile)
         @database = Database.new
-        @lockfile = LockfileParser.new(
-          File.read(File.join(@root,gemfile_lock))
-        )
+        @lockfile = LockfileParser.new(lockfile)
       end
 
       #

--- a/spec/lockfile_loader_spec.rb
+++ b/spec/lockfile_loader_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'tmpdir'
+require 'bundler/audit/lockfile_loader'
+
+describe LockfileLoader do
+  describe "#initialize" do
+    let(:path) { "/path/to/project" }
+
+    subject { described_class.new(path) }
+
+    it "initializes with a path" do
+      expect(subject.path).to eq(path)
+    end
+  end
+
+  describe "#contents" do
+    before {
+      stub_const("Bundler::VERSION", "1.8.0")
+    }
+
+    let(:expected) { "expected lockfile contents" }
+
+    it "takes gems.locked first" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "gems.locked"), expected)
+        File.write(File.join(dir, "Gemfile.lock"), "unexpected")
+
+        expect(LockfileLoader.new(dir).contents).to eq(expected)
+      end
+    end
+
+    it "falls back to Gemfile.lock" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "Gemfile.lock"), expected)
+
+        expect(LockfileLoader.new(dir).contents).to eq(expected)
+      end
+    end
+
+    it "raises if none are found" do
+      Dir.mktmpdir do |dir|
+        loader = LockfileLoader.new(dir)
+        expect { loader.contents }.to raise_error(StandardError)
+      end
+    end
+  end
+
+  describe ".lockfile_names" do
+    subject { described_class.lockfile_names }
+
+    it "returns just the legacy Gemfile.lock for old bundler versions" do
+      stub_const("Bundler::VERSION", "1.7.9")
+      expect(subject).to eq(["Gemfile.lock"])
+    end
+
+    it "returns the order lits of gems.locked then Gemfile.lock for newer bundler versions" do
+      stub_const("Bundler::VERSION", "1.8.0")
+      expect(subject).to eq(["gems.locked", "Gemfile.lock"])
+    end
+  end
+end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -2,11 +2,14 @@ require 'spec_helper'
 require 'bundler/audit/scanner'
 
 describe Scanner do
+  let(:scanner) { described_class.new(lockfile_contents) }
+  let(:lockfile_contents) { File.read(File.join(directory, 'Gemfile.lock')) }
+
   describe "#scan" do
     let(:bundle)    { 'unpatched_gems' }
     let(:directory) { File.join('spec','bundle',bundle) }
 
-    subject { described_class.new(directory) }
+    subject { scanner }
 
     it "should yield results" do
       results = []
@@ -26,7 +29,6 @@ describe Scanner do
   context "when auditing a bundle with unpatched gems" do
     let(:bundle)    { 'unpatched_gems' }
     let(:directory) { File.join('spec','bundle',bundle) }
-    let(:scanner)  { described_class.new(directory)    }
 
     subject { scanner.scan.to_a }
 
@@ -41,7 +43,7 @@ describe Scanner do
 
       it "should ignore the specified advisories" do
         ids = subject.map { |result| result.advisory.id }
-        
+
         expect(ids).not_to include('OSVDB-89026')
       end
     end
@@ -50,7 +52,6 @@ describe Scanner do
   context "when auditing a bundle with insecure sources" do
     let(:bundle)    { 'insecure_sources' }
     let(:directory) { File.join('spec','bundle',bundle) }
-    let(:scanner)   { described_class.new(directory)    }
 
     subject { scanner.scan.to_a }
 
@@ -63,7 +64,6 @@ describe Scanner do
   context "when auditing a secure bundle" do
     let(:bundle)    { 'secure' }
     let(:directory) { File.join('spec','bundle',bundle) }
-    let(:scanner)   { described_class.new(directory)    }
 
     subject { scanner.scan.to_a }
 


### PR DESCRIPTION
Closes #143 

@JuanitoFatas @postmodern 

This takes a second try at adding `gems.locked` support.

The first commit refactors the `Scanner` class to just take the contents of a lockfile. it shouldn't have to care where it comes from.

The second commit adds a `LockfileLoader` which understands the folder, Bundler versions, and which lockfile to load.