### PR TITLE
Exit with error code when Bundler::Audit::Database.update! returns nil

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -74,6 +74,7 @@ module Bundler
           exit 1
         when nil
           say "Skipping update", :yellow
+          exit 1
         end
 
         unless options.quiet?


### PR DESCRIPTION
## The problem

We run a script along the lines of `bundle-audit update && bundle-audit` as part of our CI pipeline, which is run through Docker. Our docker container for CI is fairly minimal doesn't have git available. `system 'unknown_command'` returns nil, and bundle-audit reports `Skipping update`. We didn't notice this error message, and as a result our security check was running against outdated advisories for some time. We'd like this kind of error to be picked up by our CI, since it means that we didn't successfully check our gem security. But since bundle-audit exits with 0, our CI scripts didn't pick it up.

Relevant code:
- https://github.com/rubysec/bundler-audit/blob/master/lib/bundler/audit/database.rb#L97
- https://github.com/rubysec/bundler-audit/blob/master/lib/bundler/audit/cli.rb#L76

## The proposed solution

If something gets in the way of checking security against the latest advisories, we'd like our build to err on the side of failing so we can investigate the error. This PR offers the simplest solution (`exit 1` on this error) as a starting point for discussion. Perhaps this would be sufficient, or perhaps we need something more sophisticated.