### PR TITLE
Add --no-exit-on-warn flag that exits with 0 even when vulnerable

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,6 +34,7 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
+      method_option :no_exit_on_warn, :type => :boolean
 
       def check
         update if options[:update]
@@ -54,6 +55,7 @@ module Bundler
 
         if vulnerable
           say "Vulnerabilities found!", :red
+          exit 0 if options.no_exit_on_warn?
           exit 1
         else
           say("No vulnerabilities found", :green) unless options.quiet?


### PR DESCRIPTION
## Issue
I would like to run bundler-audit as part of our CI builds that test every branch/PR, however I do not want vulnerabilities to cause the build to be considered a failure.
Obviously, this can be achieved in bash but Brakeman, which we also run, provides a `--no-exit-on-warn` flag for this purpose.

## Fix
Added a `--no-exit-on-warn` flag that causes the CLI to exit with 0, even if vulnerabilities are found.
Error cases, such as update failing, should be unaffected by this change.