### PR TITLE
Ability to define the Gemfile via BUNDLE_GEMFILE 

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -37,8 +37,8 @@ module Bundler
 
       def check
         update if options[:update]
-
-        scanner    = Scanner.new
+        gemfile_lock = ENV['BUNDLE_GEMFILE'] ? ENV['BUNDLE_GEMFILE'] + '.lock' : 'Gemfile.lock'
+        scanner    = Scanner.new gemfile_lock
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -22,9 +22,6 @@ module Bundler
       # @return [Database]
       attr_reader :database
 
-      # Project root directory
-      attr_reader :root
-
       # The parsed `Gemfile.lock` from the project
       #
       # @return [Bundler::LockfileParser]
@@ -33,17 +30,14 @@ module Bundler
       #
       # Initializes a scanner.
       #
-      # @param [String] root
-      #   The path to the project root.
-      #
+
       # @param [String] gemfile_lock
-      #   Alternative name for the `Gemfile.lock` file.
+      #   Alternative path for the `Gemfile.lock` file.
       #
-      def initialize(root=Dir.pwd,gemfile_lock='Gemfile.lock')
-        @root     = File.expand_path(root)
+      def initialize(gemfile_lock=File.join(Dir.pwd,'Gemfile.lock'))
         @database = Database.new
         @lockfile = LockfileParser.new(
-          File.read(File.join(@root,gemfile_lock))
+          File.read(gemfile_lock)
         )
       end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -79,6 +79,16 @@ Insecure Source URI found: http://rubygems.org/
     end
   end
 
+  context "when auditing a specific Gemfile using BUNDLE_GEMFILE" do
+    subject do
+       sh("BUNDLE_GEMFILE=spec/bundle/secure/Gemfile #{command}")
+    end
+
+    it "should print nothing when everything is fine" do
+      expect(subject.strip).to eq("No vulnerabilities found")
+    end
+  end
+
   describe "update" do
 
     let(:update_command) { "#{command} update" }

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -3,10 +3,9 @@ require 'bundler/audit/scanner'
 
 describe Scanner do
   describe "#scan" do
-    let(:bundle)    { 'unpatched_gems' }
-    let(:directory) { File.join('spec','bundle',bundle) }
+    let(:gemfile_lock) { File.join('spec','bundle','unpatched_gems','Gemfile.lock') }
 
-    subject { described_class.new(directory) }
+    subject { described_class.new(gemfile_lock) }
 
     it "should yield results" do
       results = []
@@ -24,9 +23,9 @@ describe Scanner do
   end
 
   context "when auditing a bundle with unpatched gems" do
-    let(:bundle)    { 'unpatched_gems' }
-    let(:directory) { File.join('spec','bundle',bundle) }
-    let(:scanner)  { described_class.new(directory)    }
+    let(:gemfile_lock) { File.join('spec','bundle','unpatched_gems','Gemfile.lock') }
+
+    let(:scanner)  { described_class.new(gemfile_lock)    }
 
     subject { scanner.scan.to_a }
 
@@ -41,16 +40,16 @@ describe Scanner do
 
       it "should ignore the specified advisories" do
         ids = subject.map { |result| result.advisory.id }
-        
+
         expect(ids).not_to include('OSVDB-89026')
       end
     end
   end
 
   context "when auditing a bundle with insecure sources" do
-    let(:bundle)    { 'insecure_sources' }
-    let(:directory) { File.join('spec','bundle',bundle) }
-    let(:scanner)   { described_class.new(directory)    }
+    let(:gemfile_lock) { File.join('spec','bundle','insecure_sources','Gemfile.lock') }
+
+    let(:scanner)   { described_class.new(gemfile_lock)    }
 
     subject { scanner.scan.to_a }
 
@@ -61,9 +60,9 @@ describe Scanner do
   end
 
   context "when auditing a secure bundle" do
-    let(:bundle)    { 'secure' }
-    let(:directory) { File.join('spec','bundle',bundle) }
-    let(:scanner)   { described_class.new(directory)    }
+    let(:gemfile_lock) { File.join('spec','bundle','secure','Gemfile.lock') }
+
+    let(:scanner)   { described_class.new(gemfile_lock)    }
 
     subject { scanner.scan.to_a }
 


### PR DESCRIPTION
When using bundler, a common strategy to handle different Gemfiles for a project is to use the environment variable BUNDLE_GEMFILE. Bundle audit does not support to set a specific Gemfile. This pull request addes this abillity.

Example:
```
markus@markuss-mbp ~/workspace/bundler-audit (master) $ BUNDLE_GEMFILE=../helena/gemfiles/rails_4.2.gemfile bin/bundle-audit 
No vulnerabilities found
markus@markuss-mbp ~/workspace/bundler-audit (master) $ BUNDLE_GEMFILE=../helena/gemfiles/rails_5.1.gemfile bin/bundle-audit 
Name: loofah
Version: 2.2.2
Advisory: CVE-2018-16468
Criticality: Unknown
URL: https://github.com/flavorjones/loofah/issues/154
Title: Loofah XSS Vulnerability
Solution: upgrade to >= 2.2.3

Name: nokogiri
Version: 1.8.4
Advisory: CVE-2018-14404
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1785
Title: Nokogiri gem, via libxml2, is affected by multiple vulnerabilities
Solution: upgrade to >= 1.8.5

Name: rubyzip
Version: 1.2.1
Advisory: CVE-2018-1000544
Criticality: Unknown
URL: https://github.com/rubyzip/rubyzip/issues/369
Title: Directory Traversal in rubyzip
Solution: upgrade to >= 1.2.2

Vulnerabilities found!
```