### PR TITLE
set bundler requirement to be < 3

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -11,4 +11,4 @@ required_rubygems_version: ">= 1.8.0"
 
 dependencies:
   thor: ~> 0.18
-  bundler: ~> 1.2
+  bundler: < 3.0


### PR DESCRIPTION
Hi! I'm the current release manager for Bundler, i'm going around the ruby ecosystem and seeing if there is anything i can do to help everyone prepare for the upcoming Bundler 2 release.

I noticed that the `bundler-audit` gem is locked to version 1.X at the moment. We can safely change this requirement to be `< 3`, Bundler 2 has no breaking changes that will effect this gem.

Thanks!