### PR TITLE
Add support for --gemfile command line option

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,11 +34,13 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
+      method_option :gemfile, :type => :string
 
       def check
         update if options[:update]
 
-        scanner    = Scanner.new
+        gemfile    = options[:gemfile] || "Gemfile"
+        scanner    = Scanner.new(Dir.pwd, "#{gemfile}.lock")
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|


### PR DESCRIPTION
This allows bundler-audit to run files other than Gemfile.lock by passing the name of the Gemfile:

```bash
# Instead of auditing Gemfile.lock, it would audit Gemfile.next.lock
bundle-audit --gemfile Gemfile.next
```

This is useful for gems that run multiple Gemfiles for compatibility reasons or apps that use a second Gemfile to dual-boot Rails. (The latter is the case that matters to me :smile:)

Is this a change you would be open to accepting? If so, I can add tests and polish the implementation.