### PR TITLE
cli: allow --file option to target a different locked gemfile

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,11 +34,16 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
+      method_option :file, type: :string, aliases: "-f"
 
       def check
         update if options[:update]
 
-        scanner    = Scanner.new
+        scanner = if options[:file]
+          Scanner.new(Dir.pwd, options[:file])
+        else
+          Scanner.new
+        end
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|


### PR DESCRIPTION
This changes allows to specify a file target for the audit. Instead of
the default "Gemfile.lock" file a custom gem lock file can be
specified with the new `--file gems.locked` CLI option

Replaces #207 