### PR TITLE
Specify `--no-rebase` when updating database

### DIFF
--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -99,7 +99,7 @@ module Bundler
         if File.directory?(USER_PATH)
           if File.directory?(File.join(USER_PATH, ".git"))
             Dir.chdir(USER_PATH) do
-              command = %w(git pull)
+              command = %w(git pull --no-rebase)
               command << '--quiet' if options[:quiet]
               command << 'origin' << 'master'
               system *command

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ module Helpers
   def expect_update_to_update_repo!
     expect(Bundler::Audit::Database).
       to receive(:system).
-      with('git', 'pull', 'origin', 'master').
+      with('git', 'pull', '--no-rebase', 'origin', 'master').
       and_call_original
   end
 


### PR DESCRIPTION
Hi!  I'm working on using your project to help with semi-automated updates of ruby packages in the nixpkgs package repository (nixos/nixpkgs#64822).  I noticed that I consistently saw this error when I ran my script for several packages concurrently:
```
fatal: Cannot rebase onto multiple branches.
Failed updating ruby-advisory-db!
```

I was able to fix the problem by removing this from my `~/.gitconfig`:
```
[pull]
     rebase = true
```

So I think this change would help my edge case, without bothering anyone else.