### PR TITLE
Bundle audit extended to report GitHub Security Advisories (GHSAs)

### DIFF
--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -28,6 +28,7 @@ module Bundler
                                 :cvss_v2,
                                 :cve,
                                 :osvdb,
+                                :ghsa,
                                 :unaffected_versions,
                                 :patched_versions)
 
@@ -65,6 +66,7 @@ module Bundler
           data['cvss_v2'],
           data['cve'],
           data['osvdb'],
+          data['ghsa'],
           parse_versions[data['unaffected_versions']],
           parse_versions[data['patched_versions']]
         )
@@ -86,6 +88,15 @@ module Bundler
       #
       def osvdb_id
         "OSVDB-#{osvdb}" if osvdb
+      end
+
+      #
+      # The GHSA (GitHub Security Advisory) identifier
+      #
+      # @return [String, nil]
+      #
+      def ghsa_id
+        "GHSA-#{ghsa}" if ghsa
       end
 
       #

--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -99,10 +99,6 @@ module Bundler
         "GHSA-#{ghsa}" if ghsa
       end
 
-      def has_supported_identifier?
-        cve || osvdb || ghsa
-      end
-
       #
       # Determines how critical the vulnerability is.
       #

--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -100,6 +100,16 @@ module Bundler
       end
 
       #
+      # Return a compacted list of all ids
+      def identifiers
+        [
+          cve_id,
+          osvdb_id,
+          ghsa_id
+        ].compact
+      end
+
+      #
       # Determines how critical the vulnerability is.
       #
       # @return [:low, :medium, :high]

--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -99,6 +99,10 @@ module Bundler
         "GHSA-#{ghsa}" if ghsa
       end
 
+      def has_supported_identifier?
+        cve || osvdb || ghsa
+      end
+
       #
       # Determines how critical the vulnerability is.
       #

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -109,9 +109,11 @@ module Bundler
         say "Advisory: ", :red
 
         if advisory.cve
-          say "CVE-#{advisory.cve}"
+          say advisory.cve_id
         elsif advisory.osvdb
           say advisory.osvdb
+        elsif advisory.ghsa
+          say advisory.ghsa_id
         end
 
         say "Criticality: ", :red

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -111,7 +111,7 @@ module Bundler
         if advisory.cve
           say advisory.cve_id
         elsif advisory.osvdb
-          say advisory.osvdb
+          say advisory.osvdb_id
         elsif advisory.ghsa
           say advisory.ghsa_id
         end

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -148,9 +148,12 @@ module Bundler
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
-            if advisory.has_supported_identifier?
-              yield UnpatchedGem.new(gem,advisory)
-            end
+            is_ignored = ignore.include?(advisory.cve_id) ||
+                         ignore.include?(advisory.osvdb_id) ||
+                         ignore.include?(advisory.ghsa_id)
+            next if is_ignored
+
+            yield UnpatchedGem.new(gem,advisory)
           end
         end
       end

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -148,9 +148,7 @@ module Bundler
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
-            is_ignored = ignore.include?(advisory.cve_id) ||
-                         ignore.include?(advisory.osvdb_id) ||
-                         ignore.include?(advisory.ghsa_id)
+            is_ignored = ignore.intersect?(advisory.identifiers.to_set)
             next if is_ignored
 
             yield UnpatchedGem.new(gem,advisory)

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -148,8 +148,7 @@ module Bundler
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
-            unless (ignore.include?(advisory.cve_id) ||
-                    ignore.include?(advisory.osvdb_id))
+            if advisory.has_supported_identifier?
               yield UnpatchedGem.new(gem,advisory)
             end
           end

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -83,28 +83,6 @@ describe Bundler::Audit::Advisory do
     end
   end
 
-  describe "#has_supported_identifier?" do
-    it "should return false if an advisory has no CVE, OSVDB, nor GHSA ID" do
-      advisory = described_class.new.tap do |advisory|
-        advisory.cve = nil
-        advisory.osvdb = nil
-        advisory.ghsa = nil
-      end
-
-      expect(advisory.has_supported_identifier?).to be_falsey
-    end
-
-    it "should return true if an advisory has a CVE" do
-      advisory = described_class.new.tap do |advisory|
-        advisory.cve = "2019-12345"
-        advisory.osvdb = nil
-        advisory.ghsa = nil
-      end
-
-      expect(advisory.has_supported_identifier?).to be_truthy
-    end
-  end
-
   describe "#cve_id" do
     let(:cve) { "2015-1234" }
 

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -83,6 +83,28 @@ describe Bundler::Audit::Advisory do
     end
   end
 
+  describe "#has_supported_identifier?" do
+    it "should return false if an advisory has no CVE, OSVDB, nor GHSA ID" do
+      advisory = described_class.new.tap do |advisory|
+        advisory.cve = nil
+        advisory.osvdb = nil
+        advisory.ghsa = nil
+      end
+
+      expect(advisory.has_supported_identifier?).to be_falsey
+    end
+
+    it "should return true if an advisory has a CVE" do
+      advisory = described_class.new.tap do |advisory|
+        advisory.cve = "2019-12345"
+        advisory.osvdb = nil
+        advisory.ghsa = nil
+      end
+
+      expect(advisory.has_supported_identifier?).to be_truthy
+    end
+  end
+
   describe "#cve_id" do
     let(:cve) { "2015-1234" }
 

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -123,6 +123,26 @@ describe Bundler::Audit::Advisory do
     end
   end
 
+  describe "#ghsa_id" do
+    let(:ghsa) { "xfhh-rx56-rxcr" }
+
+    subject do
+      described_class.new.tap do |advisory|
+        advisory.ghsa = ghsa
+      end
+    end
+
+    it "should prepend GHSA- to the GHSA id" do
+      expect(subject.ghsa_id).to be == "GHSA-#{ghsa}"
+    end
+
+    context "when ghsa is nil" do
+      subject { described_class.new }
+
+      it { expect(subject.ghsa_id).to be_nil }
+    end
+  end
+
   describe "#criticality" do
     context "when cvss_v2 is between 0.0 and 3.3" do
       subject do

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -143,6 +143,37 @@ describe Bundler::Audit::Advisory do
     end
   end
 
+  describe "#identifiers" do
+    it "should include all identifiers if defined" do
+      advisory = described_class.new.tap do |advisory|
+        advisory.cve = "2018-1234"
+        advisory.osvdb = "2019-2345"
+        advisory.ghsa = "2020-3456"
+      end
+
+      expect(advisory.identifiers).to eq([
+        "CVE-2018-1234",
+        "OSVDB-2019-2345",
+        "GHSA-2020-3456"
+      ])
+    end
+
+    it "should exclude nil identifiers" do
+      advisory = described_class.new
+      expect(advisory.identifiers).to eq([])
+
+      advisory = described_class.new.tap do |advisory|
+        advisory.cve = "2018-1234"
+      end
+      expect(advisory.identifiers).to eq(["CVE-2018-1234"])
+
+      advisory = described_class.new.tap do |advisory|
+        advisory.ghsa = "2020-3456"
+      end
+      expect(advisory.identifiers).to eq(["GHSA-2020-3456"])
+    end
+  end
+
   describe "#criticality" do
     context "when cvss_v2 is between 0.0 and 3.3" do
       subject do

--- a/spec/bundle/unpatched_gems/Gemfile
+++ b/spec/bundle/unpatched_gems/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', '4.2.7'
+gem 'activerecord', '3.2.10'

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -31,18 +31,19 @@ describe Scanner do
     subject { scanner.scan.to_a }
 
     it "should match unpatched gems to their advisories" do
+      ids = subject.map { |result| result.advisory.id }
+      expect(ids).to include('OSVDB-89025')
       expect(subject.all? { |result|
         result.advisory.vulnerable?(result.gem.version)
       }).to be_truthy
     end
 
     context "when the :ignore option is given" do
-      subject { scanner.scan(:ignore => ['OSVDB-89026']) }
+      subject { scanner.scan(:ignore => ['OSVDB-89025']) }
 
       it "should ignore the specified advisories" do
         ids = subject.map { |result| result.advisory.id }
-        
-        expect(ids).not_to include('OSVDB-89026')
+        expect(ids).not_to include('OSVDB-89025')
       end
     end
   end


### PR DESCRIPTION
## Overview

This PR extends `bundle audit` so it will report GitHub Security Advisories, in addition to the CVEs and OSVDB advisories it already reports.

I did some very mild refactoring, adding a `has_supported_identifier?` method to contain some stray logic.  I considered doing more extensive refactoring,  but in the end decided to keep the change minimal for now.

## Related links

- This PR adds the first GHSA into rubysec/advisory-db: https://github.com/rubysec/ruby-advisory-db/pull/397
- And some discussion noting the need to also extend bundler-audit, as is done here: https://github.com/rubysec/ruby-advisory-db/pull/397#issuecomment-507946376

## Sample output

This is what a GHSA report looks like:
```
$  bundle audit
Name: yard
Version: 0.9.19
Advisory: GHSA-xfhh-rx56-rxcr
Criticality: Unknown
URL: https://github.com/lsegal/yard/security/advisories/GHSA-xfhh-rx56-rxcr
Title: Possible arbitrary path traversal and file access via `yard server`
Solution: upgrade to >= 0.9.20

Vulnerabilities found!
```

CC @reedloden @jychen7 @phillmv @mveytsman 