### PR TITLE
Separate lockfile parsing from vulnerability scanning

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -15,7 +15,7 @@
 # along with bundler-audit.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-require 'bundler/audit/scanner'
+require 'bundler/audit/file_scanner'
 require 'bundler/audit/version'
 
 require 'thor'
@@ -38,7 +38,7 @@ module Bundler
       def check
         update if options[:update]
 
-        scanner    = Scanner.new
+        scanner    = FileScanner.new
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|

--- a/lib/bundler/audit/file_scanner.rb
+++ b/lib/bundler/audit/file_scanner.rb
@@ -1,0 +1,26 @@
+require 'bundler/audit/scanner'
+
+module Bundler
+  module Audit
+    class FileScanner < Scanner
+
+      # Project root directory
+      attr_reader :root
+
+      #
+      # Initializes a file scanner.
+      #
+      # @param [String] root
+      #   The path to the project root.
+      #
+      # @param [String] gemfile_lock
+      #   Alternative name for the `Gemfile.lock` file.
+      #
+      def initialize(root=Dir.pwd,gemfile_lock='Gemfile.lock')
+        @root = File.expand_path(root)
+        super(LockfileParser.new(File.read(File.join(@root,gemfile_lock))))
+      end
+    end
+  end
+end
+

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -22,9 +22,6 @@ module Bundler
       # @return [Database]
       attr_reader :database
 
-      # Project root directory
-      attr_reader :root
-
       # The parsed `Gemfile.lock` from the project
       #
       # @return [Bundler::LockfileParser]
@@ -33,18 +30,12 @@ module Bundler
       #
       # Initializes a scanner.
       #
-      # @param [String] root
-      #   The path to the project root.
+      # @param [Bunder::LockfileParser] lockfile
+      #   A parsed lockfile.
       #
-      # @param [String] gemfile_lock
-      #   Alternative name for the `Gemfile.lock` file.
-      #
-      def initialize(root=Dir.pwd,gemfile_lock='Gemfile.lock')
-        @root     = File.expand_path(root)
+      def initialize(lockfile)
         @database = Database.new
-        @lockfile = LockfileParser.new(
-          File.read(File.join(@root,gemfile_lock))
-        )
+        @lockfile = lockfile
       end
 
       #

--- a/spec/file_scanner_spec.rb
+++ b/spec/file_scanner_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'bundler/audit/scanner'
+require 'bundler/audit/file_scanner'
 
-describe Scanner do
+describe FileScanner do
   describe "#scan" do
     let(:bundle)    { 'unpatched_gems' }
     let(:directory) { File.join('spec','bundle',bundle) }


### PR DESCRIPTION
Hi,

i would like you to use the bundler-audit library for scanning lockfiles stored in a database, rather than beeing available as actual files. So i changed `Scanner#initialize` to take a `Bundler::LockfileParser` as argument und introduced `FileScanner` to do the file opening, reading and parsing.

This change breaks API. I am not sure how many people (if any) are using the projects lib and what your policy is regarding breaking changes. If you like to stay backwards compatible i can update the PR.

Cheers, ushi