### PR TITLE
Allow db path to be customizable

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,6 +34,7 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
+      method_option :db_path, :type => :string, :aliases => '-p', default: nil
 
       def check
         update if options[:update]
@@ -66,7 +67,7 @@ module Bundler
       def update
         say("Updating ruby-advisory-db ...") unless options.quiet?
 
-        case Database.update!(quiet: options.quiet?)
+        case Database.update!(quiet: options.quiet?, db_path: options.db_path)
         when true
           say("Updated ruby-advisory-db", :green) unless options.quiet?
         when false

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,7 +34,7 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
-      method_option :db_path, :type => :string, :aliases => '-p', :default => File.join(Dir.home, '.local', 'share', 'ruby-advisory-db')
+      method_option :db_path, :type => :string, :aliases => '-p', :default => Bundler::Audit::Database::USER_PATH
 
       def check
         update if options[:update]

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,7 +34,7 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
-      method_option :db_path, :type => :string, :aliases => '-p', default: nil
+      method_option :db_path, :type => :string, :aliases => '-p', :default => File.join(Dir.home, '.local', 'share', 'ruby-advisory-db')
 
       def check
         update if options[:update]

--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -95,10 +95,12 @@ module Bundler
       # @since 0.3.0
       #
       def self.update!(options={})
-        raise "Invalid option(s)" unless (options.keys - [:quiet]).empty?
-        if File.directory?(USER_PATH)
-          if File.directory?(File.join(USER_PATH, ".git"))
-            Dir.chdir(USER_PATH) do
+        raise "Invalid option(s)" unless (options.keys - [:quiet, :db_path]).empty?
+        db_path = options[:db_path] || USER_PATH
+
+        if File.directory?(db_path)
+          if File.directory?(File.join(db_path, ".git"))
+            Dir.chdir(db_path) do
               command = %w(git pull)
               command << '--quiet' if options[:quiet]
               command << 'origin' << 'master'
@@ -108,7 +110,7 @@ module Bundler
         else
           command = %w(git clone)
           command << '--quiet' if options[:quiet]
-          command << URL << USER_PATH
+          command << URL << db_path
           system *command
         end
       end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -50,14 +50,14 @@ describe Bundler::Audit::CLI do
 
     context "--quiet" do
       before do
-        allow(subject).to receive(:options).and_return(double("Options", quiet?: true))
+        allow(subject).to receive(:options).and_return(double("Options", quiet?: true, db_path: nil))
       end
 
       context "when update succeeds" do
 
         before do
           expect(Bundler::Audit::Database).to(
-            receive(:update!).with(quiet: true).and_return(true)
+            receive(:update!).with(quiet: true, db_path: nil).and_return(true)
           )
         end
 
@@ -70,7 +70,7 @@ describe Bundler::Audit::CLI do
 
         before do
           expect(Bundler::Audit::Database).to(
-            receive(:update!).with(quiet: true).and_return(false)
+            receive(:update!).with(quiet: true, db_path: nil).and_return(false)
           )
         end
 

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -49,6 +49,13 @@ describe Bundler::Audit::Database do
       Bundler::Audit::Database.update!(quiet: false)
       expect(File.directory?(mocked_user_path)).to be true
     end
+
+    it "should recieve db_path and allow a customizable directory" do
+      db_path = File.expand_path('../../tmp/customizable-ruby-advisory-db', __FILE__)
+
+      Bundler::Audit::Database.update!(quiet: false, db_path: db_path)
+      expect(File.directory?(db_path)).to be true
+    end
   end
 
   describe "#initialize" do


### PR DESCRIPTION
As it stands, the database must be downloaded to 

```
USER_PATH = File.expand_path(File.join(ENV['HOME'],'.local','share','ruby-advisory-db'))
```

However this breaks one of the principles of CI that everything should be installed into the local workspace directory.

This PR adds the option to optionally specify a `db_path` so that a customized directory can be set for the update.

I suspect there are other updates that may be required. Looking for feedback on whether this concept is the right way to fix this issue. 😺 