### PR TITLE
Fix Scanner#internal_source? w/ Bundler::URI::HTTP

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -167,7 +167,7 @@ module Bundler
       # @return [Boolean]
       #
       def internal_source?(uri)
-        uri = URI(uri)
+        uri = URI.parse(uri.to_s)
 
         internal_host?(uri.host) if uri.host
       end


### PR DESCRIPTION
Trying to use bundler-audit with Bundler 2.1.1 fails because
`Scanner#internal_source?` gets passed a `Bundler::URI::HTTP` instance.

```
uri/common.rb:745:in `URI': bad argument (expected URI object or URI string) (ArgumentError)
```

This patch uses `#to_s` on the passed object to work around that issue.