### PR TITLE
Fix internal source check in scanner

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -167,7 +167,7 @@ module Bundler
       # @return [Boolean]
       #
       def internal_source?(uri)
-        uri = URI(uri)
+        uri = URI(uri.to_s)
 
         internal_host?(uri.host) if uri.host
       end


### PR DESCRIPTION
This change converts the input `uri` to a string within the `internal_source?` method to avoid the `ArgumentError` issue from #235.