### PR TITLE
ruby 2.3 EOL deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
-rvm:
-  - 2.3
+rvm:  
   - 2.4
   - 2.5
   - 2.6


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/