### PR TITLE
Use non-zero exit code if there's an argument error when running through CLI

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -156,6 +156,10 @@ module Bundler
         say
       end
 
+      def self.exit_on_failure?
+        true
+      end
+
     end
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2,6 +2,19 @@ require 'spec_helper'
 require 'bundler/audit/cli'
 
 describe Bundler::Audit::CLI do
+  describe "#start" do
+    context "with wrong arguments" do
+      it "exits with error status code" do
+        expect {
+          described_class.start ["check", "--ignore CVE-2015-9284"]
+        }.to raise_error(SystemExit) do |error|
+          expect(error.success?).to eq(false)
+          expect(error.status).to eq(1)
+        end
+      end
+    end
+  end
+
   describe "#update" do
     context "not --quiet (the default)" do
       context "when update succeeds" do


### PR DESCRIPTION
Our CircleCI build was passing (and failing silently) when running bundle-audit since we were not passing the right arguments to the `start` method.

Now when we run our custom bundler audit Rake task, which uses the CLI directly, we get a non-zero exit error when we pass the wrong arguments:

Without this PR:
```
➜  bundle exec rake bundle:audit
ERROR: "rake check" was called with arguments ["--ignore CVE-2015-9284"]
Usage: "rake check"
➜ echo $?
0
```

With this PR:
```
➜  bundle exec rake bundle:audit
ERROR: "rake check" was called with arguments ["--ignore CVE-2015-9284"]
Usage: "rake check"
➜ echo $?
127
```