### PR TITLE
Docs: Install with bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ task default: 'bundle:audit'
 
     $ [sudo] gem install bundler-audit
 
+### Install using bundler
+
+Installation with `gem` (above) is preferred.
+
+```ruby
+# Gemfile
+group :development do
+  gem 'bundler-audit', require: false
+  # or, from source:
+  gem 'bundler-audit', github: 'rubysec/bundler-audit', require: false
+end
+```
+
 ## Contributing
 
 1. Clone the repo


### PR DESCRIPTION
My team requires all gems to be listed in `Gemfile`. Also, we are installing from source right now so that we can use the latest `thor` (pending the release of `0.7`).

Maybe we're the only ones, but just in case it helps someone else ..