### PR TITLE
support for ruby 2.4 has ended

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:  
-  - 2.4
   - 2.5
   - 2.6
   - 2.7


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/