### PR TITLE
Doc: Add git as part of the requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ task default: 'bundle:audit'
 * [rubygems] >= 1.8
 * [thor] >= 0.18, < 2
 * [bundler] ~> 1.2
+* [git]
 
 ## Install
 
@@ -163,6 +164,7 @@ along with bundler-audit.  If not, see <http://www.gnu.org/licenses/>.
 [rubygems]: https://rubygems.org
 [thor]: http://whatisthor.com/
 [bundler]: https://github.com/carlhuda/bundler#readme
+[git]: https://github.com/git/git
 
 [OSVDB]: http://osvdb.org/
 [ruby-advisory-db]: https://github.com/rubysec/ruby-advisory-db


### PR DESCRIPTION
Hei ya team, 
I got an error saying that `Git is not installed!`
And I realized that:
1. There is a current issue with this: https://github.com/rubysec/bundler-audit/issues/267
2. In the requirement, git is not listed as part of it

We also assumed that this gem does not require git to run, so now our deployment is a little bit broken with the latest version.
By adding git as part of the requirement I believe will help the other developers in the future.

Cheers