### PR TITLE
Adds the '--lockfile' option to 'bundle-audit check' command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+### 0.7.1 / 2020-07-17
+
+* Added the `--lockfile` option to `bundle-audit check` command (@mariozaizar).
+
 ### 0.7.0.1 / 2020-06-12
 
 * Forgot to populate `data/ruby-advisory-db`.

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -34,11 +34,18 @@ module Bundler
       method_option :verbose, :type => :boolean, :aliases => '-v'
       method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
+      method_option :lockfile, :type => :string, :aliases => '-l'
 
       def check
         update if options[:update]
 
-        scanner    = Scanner.new
+        if options.lockfile
+          details = " in #{options.lockfile} lockfile"
+          scanner = Scanner.new(path=Dir.pwd, gemfile_lock=options.lockfile)
+        else
+          scanner = Scanner.new
+        end
+
         vulnerable = false
 
         scanner.scan(:ignore => options.ignore) do |result|
@@ -53,10 +60,10 @@ module Bundler
         end
 
         if vulnerable
-          say "Vulnerabilities found!", :red
+          say("Vulnerabilities found#{details}!", :red)
           exit 1
         else
-          say("No vulnerabilities found", :green) unless options.quiet?
+          say("No vulnerabilities found#{details}", :green) unless options.quiet?
         end
       end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -15,6 +15,28 @@ describe Bundler::Audit::CLI do
     end
   end
 
+  describe "#check" do
+    it "prints check message" do
+      expect { subject.check }.to output(/No vulnerabilities found/).to_stdout
+    end
+
+    context "--lockfile" do
+      let(:options) { double("Options", lockfile: gemfile_lock) }
+      let(:gemfile_lock) { 'Gemfile.lock' }
+
+      before do
+        allow(options).to receive(:[])
+        allow(options).to receive(:ignore)
+        allow(options).to receive(:quiet?)
+        allow(subject).to receive(:options).and_return(options)
+      end
+
+      it "includes the gemfile.lock path in the check message" do
+        expect { subject.check }.to output(/No vulnerabilities found in #{gemfile_lock} lockfile/).to_stdout
+      end
+    end
+  end
+
   describe "#update" do
     context "not --quiet (the default)" do
       context "when update succeeds" do


### PR DESCRIPTION
### Description

Adds the `--lockfile` option to `bundle-audit check` command.

#### Help cmd
```
bundle exec bundle-audit help check
Usage:
  bundle-audit check

Options:
  -q, [--quiet], [--no-quiet]
  -v, [--verbose], [--no-verbose]
  -i, [--ignore=one two three]
  -u, [--update], [--no-update]
  -l, [--lockfile=LOCKFILE]

Checks the Gemfile.lock for insecure dependencies
```

#### Check cmd (default options)
```
bundle exec bundle-audit check
Name: kramdown
Version: 0.14.2
Advisory: CVE-2020-14001
Criticality: Critical
URL: https://github.com/advisories/GHSA-mqm2-cgpr-p4m6
Title: Unintended read access in kramdown gem
Solution: upgrade to >= 2.3.0

Vulnerabilities found!
```

#### Check cmd with `--lockfile` and vulnerabilities found 🔴 
```
bundle exec bundle-audit check --lockfile=rails5.2.gemfile.lock
Name: brakeman
Version: 4.6.1
Advisory: CVE-2019-18409
Criticality: High
URL: https://brakemanscanner.org/blog/2019/10/14/brakeman-4-dot-7-dot-1-released
Title: brakeman world writable files allow local privilege escalation
Solution: upgrade to >= 4.7.1

Vulnerabilities found in rails5.2.gemfile.lock lockfile!
```

#### Check cmd with `--lockfile` and  no vulnerabilities found 🟢 
```
bundle exec bundle-audit check --lockfile=rails6.0.gemfile.lock
No vulnerabilities found in rails6.0.gemfile.lock lockfile
```

This could be useful to test lock files individually on projects that support multiple Rails versions. E.g. `Rakefile`:

```ruby
require 'bundler/audit/cli'

namespace :bundle do
  desc "Runs bundle:audit"
  task :audit do
    gemfile_lock = ENV['BUNDLE_GEMFILE']
    audit_args = ["check", "--verbose", "--update", "--lockfile=#{gemfile_lock}"]

    Bundler::Audit::CLI.start(audit_args)
  end
end
```

Then in `.github/actions.yml`:

```yml
name: actions
on: [push]
jobs:
  main:
    strategy:
      matrix:
        gemfile:
          - gemfiles/rails5.1.gemfile
          - gemfiles/rails5.2.gemfile
          - gemfiles/rails6.0.gemfile
        task:
          - "test"
          - "bundle:audit"
```