### PR TITLE
Docs: Fix README link reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ along with bundler-audit.  If not, see <http://www.gnu.org/licenses/>.
 [ruby]: https://ruby-lang.org
 [rubygems]: https://rubygems.org
 [thor]: http://whatisthor.com/
-[bundler]: https://github.com/carlhuda/bundler#readme
+[bundler]: https://bundler.io
 
 [OSVDB]: http://osvdb.org/
 [ruby-advisory-db]: https://github.com/rubysec/ruby-advisory-db

--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ along with bundler-audit.  If not, see <http://www.gnu.org/licenses/>.
 [rubygems]: https://rubygems.org
 [thor]: http://whatisthor.com/
 [bundler]: https://github.com/carlhuda/bundler#readme
-[git]: https://github.com/git/git
 
 [OSVDB]: http://osvdb.org/
 [ruby-advisory-db]: https://github.com/rubysec/ruby-advisory-db


### PR DESCRIPTION
Fix `[git]` and `[bundler]` link references.
See each commit for details.