### PR TITLE
Use YAML.safe_load

### DIFF
--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -45,7 +45,7 @@ module Bundler
       #
       def self.load(path)
         id   = File.basename(path).chomp('.yml')
-        data = YAML.load_file(path)
+        data = File.open(path){|yaml| YAML.safe_load(yaml, [Date])}
 
         unless data.kind_of?(Hash)
           raise("advisory data in #{path.dump} was not a Hash")


### PR DESCRIPTION
I changed `YAML.load_file` to `YAML.safe_load` because it can deserialize unexpected classes.

RCE can occur if there are no restrictions on the classes that can be deserialized, if the ruby-advisory-db git repository contains a specially crafted yaml file, or if it is crafted into a local cache.

FYI https://gist.github.com/staaldraad/89dffe369e1454eedd3306edc8a7e565 