### PR TITLE
Proof of concept to check the Bundler version too

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -215,7 +215,18 @@ module Bundler
                  else                     config.ignore
                  end
 
-        @lockfile.specs.each do |gem|
+        specs = @lockfile.specs
+
+        # Bundler itself doesn't appear in the list of specs in the lockfile,
+        # but the lockfile does provide a version for it
+        if @lockfile.bundler_version
+          specs << Gem::Specification.new do |s|
+            s.name = 'bundler'
+            s.version = @lockfile.bundler_version
+          end
+        end
+
+        specs.each do |gem|
           @database.check_gem(gem) do |advisory|
             is_ignored = ignore.intersect?(advisory.identifiers.to_set)
             next if is_ignored


### PR DESCRIPTION
I have no idea if this approach makes sense or not, but I wanted to start a conversation about this:

bundler-audit doesn't audit the version of Bundler itself.

Bundler doesn't appear in the specs in the Gemfile.lock, so if you are using a vulnerable version of Bundler, even if it's listed in the advisory database, bundler-audit won't tell you about it. I think that's a problem.

This might be a terrible approach but this is my shot at doing it, taking the version of Bundler from the "BUNDLED WITH" section in the lockfile. I'm not sure if that makes sense or not. Maybe it would make more sense to try to grab the version of Bundler currently in use? Or maybe the one that created the lockfile is actually the one we care about?

Anyway, I have no attachment to the code whatsoever, but I wanted to start a discussion on what I perceive as an oversight of this otherwise wonderful tool.