### PR TITLE
Support shallow clone option

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -40,6 +40,7 @@ module Bundler
                              :aliases => '-F'
       method_option :gemfile_lock, :type => :string, :aliases => '-G', :default => 'Gemfile.lock'
       method_option :output, :type => :string, :aliases => '-o'
+      method_option :depth, :type => :numeric, :aliases => '-d'
 
       def check(dir=Dir.pwd)
         unless File.directory?(dir)
@@ -55,7 +56,7 @@ module Bundler
         end
 
         if !Database.exists?(options[:database])
-          download(options[:database])
+          download(options[:database], options.depth)
         elsif options[:update]
           update(options[:database])
         end
@@ -93,17 +94,19 @@ module Bundler
 
       desc 'download', 'Downloads ruby-advisory-db'
       method_option :quiet, :type => :boolean, :aliases => '-q'
+      method_option :depth, :type => :numeric, :aliases => '-d'
 
-      def download(path=Database.path)
+      def download(path=Database.path, depth=nil)
         if Database.exists?(path)
           say "Database already exists", :yellow
           return
         end
 
         say("Download ruby-advisory-db ...") unless options.quiet?
+        depth ||= options.depth
 
         begin
-          Database.download(path: path, quiet: options.quiet?)
+          Database.download(path: path, quiet: options.quiet?, depth: depth)
         rescue Database::DownloadFailed => error
           say error.message, :red
           exit 1

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -84,6 +84,15 @@ describe Bundler::Audit::Database do
       end
     end
 
+    context "with :depth" do
+      it "should execute `git clone` with the `--depth` option" do
+        expect(subject).to receive(:system).with('git', 'clone', '--depth=1', url, path).and_return(true)
+        expect(subject).to receive(:new)
+
+        subject.download(depth: 1)
+      end
+    end
+
     context "when the command fails" do
       it do
         expect(subject).to receive(:system).with('git', 'clone', url, path).and_return(false)


### PR DESCRIPTION
I have created an option to speed up the download by using shallow clone.

```
$  time ./bin/bundle-audit --database test
Download ruby-advisory-db ...
Cloning into 'test'...
remote: Enumerating objects: 5122, done.
remote: Counting objects: 100% (125/125), done.
remote: Compressing objects: 100% (87/87), done.
remote: Total 5122 (delta 46), reused 84 (delta 26), pack-reused 4997
Receiving objects: 100% (5122/5122), 942.96 KiB | 1.79 MiB/s, done.
Resolving deltas: 100% (2503/2503), done.
ruby-advisory-db:
  advisories:	499 advisories
  last updated:	2021-05-05 17:18:38 -0400
No vulnerabilities found
./bin/bundle-audit --database test  0.40s user 0.30s system 36% cpu 1.896 total

# with depth
$ time ./bin/bundle-audit --depth 1 --database test2
Download ruby-advisory-db ...
Cloning into 'test2'...
remote: Enumerating objects: 863, done.
remote: Counting objects: 100% (863/863), done.
remote: Compressing objects: 100% (635/635), done.
remote: Total 863 (delta 52), reused 555 (delta 40), pack-reused 0
Receiving objects: 100% (863/863), 279.73 KiB | 784.00 KiB/s, done.
Resolving deltas: 100% (52/52), done.
ruby-advisory-db:
  advisories:	499 advisories
  last updated:	2021-05-05 17:18:38 -0400
No vulnerabilities found
./bin/bundle-audit --depth 1 --database test2  0.32s user 0.25s system 30% cpu 1.842 total
```

It is assumed to be used in CI that does not have a cache.