### PR TITLE
Fix text format output 

### DIFF
--- a/lib/bundler/audit/cli/formats/text.rb
+++ b/lib/bundler/audit/cli/formats/text.rb
@@ -78,10 +78,12 @@ module Bundler
 
             say "Criticality: ", :red
             case advisory.criticality
-            when :low    then say "Low"
-            when :medium then say "Medium", :yellow
-            when :high   then say "High", [:red, :bold]
-            else              say "Unknown"
+            when :none       then say "None"
+            when :low        then say "Low"
+            when :medium     then say "Medium", :yellow
+            when :high       then say "High", [:red, :bold]
+            when :critical   then say "Critical", [:red, :bold]
+            else                  say "Unknown"
             end
 
             say "URL: ", :red

--- a/spec/cli/formats/text_spec.rb
+++ b/spec/cli/formats/text_spec.rb
@@ -104,39 +104,110 @@ describe Bundler::Audit::CLI::Formats::Text do
           end
         end
 
-        context "when Advisory#criticality is :low" do
-          let(:advisory) do
-            super().tap do |advisory|
-              advisory.cvss_v2 = 0.0
+        context "when CVSS v3 is present" do
+          context "when Advisory#criticality is :none (cvss_v3 only)" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v3 = 0.0
+              end
+            end
+
+            it "must print 'Criticality: None'" do
+              expect(output_lines).to include("Criticality: None")
+            end
+          end
+          
+          context "when Advisory#criticality is :low" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v3 = 0.1
+              end
+            end
+
+            it "must print 'Criticality: Low'" do
+              expect(output_lines).to include("Criticality: Low")
             end
           end
 
-          it "must print 'Criticality: Low'" do
-            expect(output_lines).to include("Criticality: Low")
+          context "when Advisory#criticality is :medium" do
+            let(:advisory) do
+              super().tap do |advisory|
+
+                advisory.cvss_v3 = 4.0
+              end
+            end
+
+            it "must print 'Criticality: Medium'" do
+              expect(output_lines).to include("Criticality: Medium")
+            end
+          end
+
+          context "when Advisory#criticality is :high" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v3 = 7.0
+              end
+            end
+
+            it "must print 'Criticality: High'" do
+              expect(output_lines).to include("Criticality: High")
+            end
+          end
+
+          context "when Advisory#criticality is :critical (cvss_v3 only)" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v3 = 9.0
+              end
+            end
+
+            it "must print 'Criticality: High'" do
+              expect(output_lines).to include("Criticality: Critical")
+            end
           end
         end
 
-        context "when Advisory#criticality is :medium" do
+        context "when CVSS v2 is present" do
           let(:advisory) do
             super().tap do |advisory|
-              advisory.cvss_v2 = 6.9
+              advisory.cvss_v3 = nil
             end
           end
 
-          it "must print 'Criticality: Medium'" do
-            expect(output_lines).to include("Criticality: Medium")
-          end
-        end
+          context "when Advisory#criticality is :low" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v2 = 0.0
+              end
+            end
 
-        context "when Advisory#criticality is :high" do
-          let(:advisory) do
-            super().tap do |advisory|
-              advisory.cvss_v2 = 10.0
+            it "must print 'Criticality: Low'" do
+              expect(output_lines).to include("Criticality: Low")
             end
           end
 
-          it "must print 'Criticality: High'" do
-            expect(output_lines).to include("Criticality: High")
+          context "when Advisory#criticality is :medium" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v2 = 4.0
+              end
+            end
+
+            it "must print 'Criticality: Medium'" do
+              expect(output_lines).to include("Criticality: Medium")
+            end
+          end
+
+          context "when Advisory#criticality is :high" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v2 = 7.0
+              end
+            end
+
+            it "must print 'Criticality: High'" do
+              expect(output_lines).to include("Criticality: High")
+            end
           end
         end
 

--- a/spec/fixtures/advisory/CVE-2020-1234.yml
+++ b/spec/fixtures/advisory/CVE-2020-1234.yml
@@ -10,6 +10,7 @@ description: |
   This is a test advisory.
 
 cvss_v2: 10.0
+cvss_v3: 9.8
 
 unaffected_versions:
   - "< 0.1.0"


### PR DESCRIPTION
Since version **v0.8.0**, the default output (text) of the CLI is impacted by a regression.

Advisories with CVSS v3 scores have a broader range of Criticality values than with CVSS v2. `None` and `Critical` values are currently missing from the `print_advisory` method in [lib/bundler/audit/cli/formats/text.rb](https://github.com/rubysec/bundler-audit/blob/v0.8.0/lib/bundler/audit/cli/formats/text.rb#L79-L85).


This PR adds cvss_v3 value to the fixture and ensure to test output for both v2 and v3 values. This is a simle fix which keeps current architecture as is but it might be welcome to have a single place where Criticality values are defined and how they should be printed, to avoid such discrepancy in the future.



Thanks.



