### PR TITLE
Add criticality level in JSON format

### DIFF
--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -200,6 +200,11 @@ module Bundler
         id == other.id
       end
 
+      #
+      # Converts the advisory to a Hash.
+      #
+      # @return [Hash{Symbol => Object}]
+      #
       def to_h
         super.merge({
           criticality: criticality

--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -200,6 +200,12 @@ module Bundler
         id == other.id
       end
 
+      def to_h
+        super.merge({
+          criticality: criticality
+        })
+      end
+
       alias to_s id
 
     end

--- a/lib/bundler/audit/cli/formats/json.rb
+++ b/lib/bundler/audit/cli/formats/json.rb
@@ -34,23 +34,7 @@ module Bundler
           #   The output stream.
           #
           def print_report(report,output=$stdout)
-            results = report.results.map do |result|
-              mapped_result = result.to_h
-
-              case result
-              when Results::InsecureSource
-              when Results::UnpatchedGem
-                advisory = result.advisory
-                advisory_hash = advisory.to_h
-                advisory_hash[:criticality] = criticality_label advisory
-                mapped_result[:advisory] = advisory_hash
-              end
-
-              mapped_result
-            end
-
             hash = report.to_h
-            hash[:results] = results
 
             if output.tty?
               output.puts ::JSON.pretty_generate(hash)

--- a/lib/bundler/audit/cli/formats/json.rb
+++ b/lib/bundler/audit/cli/formats/json.rb
@@ -35,16 +35,18 @@ module Bundler
           #
           def print_report(report,output=$stdout)
             results = report.results.map do |result|
-              advisory = result.advisory
-              advisory_hash = advisory.to_h
+              mapped_result = result.to_h
 
-              advisory_hash[:critical_level] = criticality_label advisory
+              case result
+              when Results::InsecureSource
+              when Results::UnpatchedGem
+                advisory = result.advisory
+                advisory_hash = advisory.to_h
+                advisory_hash[:criticality] = criticality_label advisory
+                mapped_result[:advisory] = advisory_hash
+              end
 
-              {
-                type: result.class,
-                gem: result.gem,
-                advisory: advisory_hash
-              }
+              mapped_result
             end
 
             hash = report.to_h
@@ -59,9 +61,11 @@ module Bundler
 
           def criticality_label advisory
             case advisory.criticality
-              when :low    then "low"
-              when :medium then "medium"
-              when :high   then "high"
+              when :none     then "none"
+              when :low      then "low"
+              when :medium   then "medium"
+              when :high     then "high"
+              when :critical then "critical"
               else "unknown"
             end
           end

--- a/lib/bundler/audit/cli/formats/json.rb
+++ b/lib/bundler/audit/cli/formats/json.rb
@@ -34,12 +34,35 @@ module Bundler
           #   The output stream.
           #
           def print_report(report,output=$stdout)
+            results = report.results.map do |result|
+              advisory = result.advisory
+              advisory_hash = advisory.to_h
+
+              advisory_hash[:critical_level] = criticality_label advisory
+
+              {
+                type: result.class,
+                gem: result.gem,
+                advisory: advisory_hash
+              }
+            end
+
             hash = report.to_h
+            hash[:results] = results
 
             if output.tty?
               output.puts ::JSON.pretty_generate(hash)
             else
               output.write(::JSON.generate(hash))
+            end
+          end
+
+          def criticality_label advisory
+            case advisory.criticality
+              when :low    then "low"
+              when :medium then "medium"
+              when :high   then "high"
+              else "unknown"
             end
           end
         end

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -353,4 +353,12 @@ describe Bundler::Audit::Advisory do
       end
     end
   end
+
+  describe "#to_h" do
+    subject { super().to_h }
+
+    it "must include criticality: :critical" do
+      expect(subject[:criticality]).to be :critical
+    end
+  end
 end

--- a/spec/cli/formats/json_spec.rb
+++ b/spec/cli/formats/json_spec.rb
@@ -97,6 +97,7 @@ describe Bundler::Audit::CLI::Formats::JSON do
           expect(output_json[:results][0][:advisory][:cve]).to be == advisory.cve
           expect(output_json[:results][0][:advisory][:osvdb]).to be == advisory.osvdb
           expect(output_json[:results][0][:advisory][:ghsa]).to be == advisory.ghsa
+          expect(output_json[:results][0][:advisory][:criticality]).to be == advisory.criticality.to_s.downcase
           expect(output_json[:results][0][:advisory][:unaffected_versions]).to be == advisory.unaffected_versions.map(&:to_s)
           expect(output_json[:results][0][:advisory][:patched_versions]).to be == advisory.patched_versions.map(&:to_s)
         end

--- a/spec/results/unpatched_gem_spec.rb
+++ b/spec/results/unpatched_gem_spec.rb
@@ -91,7 +91,7 @@ describe Bundler::Audit::Results::UnpatchedGem do
     let(:advisory_hash) { {id: advisory.id} }
     before { expect(advisory).to receive(:to_h).and_return(advisory_hash) }
 
-    it "must inclide type: :unpatched_gem" do
+    it "must include type: :unpatched_gem" do
       expect(subject[:type]).to be :unpatched_gem
     end
 


### PR DESCRIPTION
Currently, the criticality information is missing when tried to generate the report in JSON format.

I've updated the format/json.rb to show criticality level.

fixes: #308 