### PR TITLE
fix: require CGI lib explicitly

### DIFF
--- a/lib/bundler/audit/cli/formats/junit.rb
+++ b/lib/bundler/audit/cli/formats/junit.rb
@@ -16,6 +16,7 @@
 #
 
 require 'thor'
+require 'cgi'
 
 module Bundler
   module Audit


### PR DESCRIPTION
Sorry I forgot to fully test my changes in #314 without the
development dependencies. It seems the `yard` gem which is used during
tests, [requires the `cgi` library](https://github.com/lsegal/yard/blob/359006641260eef1fe6d28f5c43c7c98d40f257d/lib/yard/templates/helpers/html_helper.rb#L2) so this was not catched during
automatic unit tests.

This fixes the use of the gem as a binary.