### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,8 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
+          - 3.1
           - jruby
           - truffleruby-head
     name: Ruby ${{ matrix.ruby }}

--- a/bundler-audit.gemspec
+++ b/bundler-audit.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |gem|
 
   glob = lambda { |patterns| gem.files & Dir[*patterns] }
 
-  gem.files = if gemspec['files'] then glob[gemspec['files']]
+  gem.files = if gemspec['files']
+                glob[gemspec['files']]
               else
                 `git ls-files`.split($/)
               end

--- a/bundler-audit.gemspec
+++ b/bundler-audit.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |gem|
   glob = lambda { |patterns| gem.files & Dir[*patterns] }
 
   gem.files = if gemspec['files'] then glob[gemspec['files']]
-              else                     `git ls-files`.split($/)
+              else
+                `git ls-files`.split($/)
               end
 
   gem.executables = gemspec.fetch('executables') do
@@ -56,4 +57,5 @@ Gem::Specification.new do |gem|
       gem.add_development_dependency(name,split[versions])
     end
   end
+  gem.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -76,7 +76,8 @@ module Bundler
         report = scanner.report(ignore: options.ignore)
 
         output = if options[:output] then File.new(options[:output],'w')
-                 else                     $stdout
+                 else
+                   $stdout
                  end
 
         print_report(report,output)

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -75,7 +75,8 @@ module Bundler
 
         report = scanner.report(ignore: options.ignore)
 
-        output = if options[:output] then File.new(options[:output],'w')
+        output = if options[:output]
+                   File.new(options[:output],'w')
                  else
                    $stdout
                  end

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -218,7 +218,8 @@ module Bundler
         return enum_for(__method__,options) unless block_given?
 
         ignore = if options[:ignore] then Set.new(options[:ignore])
-                 else                     config.ignore
+                 else
+                   config.ignore
                  end
 
         @lockfile.specs.each do |gem|

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -217,7 +217,8 @@ module Bundler
       def scan_specs(options={})
         return enum_for(__method__,options) unless block_given?
 
-        ignore = if options[:ignore] then Set.new(options[:ignore])
+        ignore = if options[:ignore]
+                   Set.new(options[:ignore])
                  else
                    config.ignore
                  end

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -46,7 +46,7 @@ describe Bundler::Audit::Advisory do
 
   describe "load" do
     let(:data) do
-      File.open( path ) do |yaml|
+      File.open(path) do |yaml|
         if Psych::VERSION >= '3.1.0'
           YAML.safe_load(yaml, permitted_classes: [Date])
         else

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -45,7 +45,16 @@ describe Bundler::Audit::Advisory do
   end
 
   describe "load" do
-    let(:data) { YAML.load_file(path) }
+    let(:data) do
+      File.open( path ) do |yaml|
+        if Psych::VERSION >= '3.1.0'
+          YAML.safe_load(yaml, permitted_classes: [Date])
+        else
+          # XXX: psych < 3.1.0 YAML.safe_load calling convention
+          YAML.safe_load(yaml, [Date])
+        end
+      end
+    end
 
     describe '#id' do
       subject { super().id }

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -292,7 +292,7 @@ describe Bundler::Audit::Database do
       let(:last_commit) { Fixtures::Database::COMMIT }
       let(:last_commit_timestamp) do
         Dir.chdir(Fixtures::Database::PATH) do
-          Time.parse(`git log --date=iso8601 --pretty="%cd" #{last_commit}`)
+          Time.parse(`git log -n 2 --date=iso8601 --pretty="%cd" #{last_commit}`)
         end
       end
 


### PR DESCRIPTION
In addition to the CI configuration change this PR makes the following changes:

* Fixes YAML load in specs to permit Date
* Limits number of commit logs passed to Time.parse in spec so the string is less than 128 characters
* Adds the MFA requirement to Rubygems publishing to satisfy Rubocop
* A few formatting changes to satisfy Rubocop