### PR TITLE
Use a less ambiguous separator for the version update suggestions

### DIFF
--- a/lib/bundler/audit/cli/formats/junit.rb
+++ b/lib/bundler/audit/cli/formats/junit.rb
@@ -101,7 +101,7 @@ module Bundler
 
           def advisory_solution(advisory)
             unless advisory.patched_versions.empty?
-              "upgrade to #{advisory.patched_versions.join(', ')}"
+              "upgrade to #{advisory.patched_versions.join(' or ')}"
             else
               "remove or disable this gem until a patch is available!"
             end

--- a/lib/bundler/audit/cli/formats/text.rb
+++ b/lib/bundler/audit/cli/formats/text.rb
@@ -105,7 +105,7 @@ module Bundler
 
             unless advisory.patched_versions.empty?
               say "Solution: upgrade to ", :red
-              say advisory.patched_versions.join(', ')
+              say advisory.patched_versions.join(" or ")
             else
               say "Solution: ", :red
               say "remove or disable this gem until a patch is available!", [:red, :bold]

--- a/spec/cli/formats/junit_spec.rb
+++ b/spec/cli/formats/junit_spec.rb
@@ -241,7 +241,7 @@ describe Bundler::Audit::CLI::Formats::Junit do
 
         context "when Advisory#patched_versions is not empty" do
           it 'must print "Solution: upgrade to ..."' do
-            expect(output).to include("Solution: upgrade to #{CGI.escapeHTML(advisory.patched_versions.join(', '))}")
+            expect(output).to include("Solution: upgrade to #{CGI.escapeHTML(advisory.patched_versions.join(' or '))}")
           end
         end
 

--- a/spec/cli/formats/text_spec.rb
+++ b/spec/cli/formats/text_spec.rb
@@ -230,7 +230,7 @@ describe Bundler::Audit::CLI::Formats::Text do
 
         context "when Advisory#patched_versions is not empty" do
           it 'must print "Solution: upgrade to ..."' do
-            expect(output_lines).to include("Solution: upgrade to #{advisory.patched_versions.join(', ')}")
+            expect(output_lines).to include("Solution: upgrade to #{advisory.patched_versions.join(' or ')}")
           end
         end
 


### PR DESCRIPTION
Suggesting a change to the separator of multiple patched versions in the `Solution:` line. The reason being that the output for some CVEs may look very misleading. An example case is [this advisory](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2022-23633.yml#L52) which uses a comma in the suggested constraint of the gem version. Currently, this leads the auditor to print out this line:

```
Solution: upgrade to ~> 5.2.6, >= 5.2.6.2, ~> 6.0.4, >= 6.0.4.6, ~> 6.1.4, >= 6.1.4.6, >= 7.0.2.2
```

This may trick the reader into thinking that either one can be chosen when really the suggestions are joined using a comma making it harder to discern them. This change uses the word `or` as the separator which should be more obvious to the reader.

```
Solution: upgrade to ~> 5.2.6, >= 5.2.6.2 or ~> 6.0.4, >= 6.0.4.6 or ~> 6.1.4, >= 6.1.4.6 or >= 7.0.2.2
```