### PR TITLE
Wrap suggested patched versions in quotes

### DIFF
--- a/lib/bundler/audit/cli/formats/junit.rb
+++ b/lib/bundler/audit/cli/formats/junit.rb
@@ -101,7 +101,7 @@ module Bundler
 
           def advisory_solution(advisory)
             unless advisory.patched_versions.empty?
-              "upgrade to #{advisory.patched_versions.join(' or ')}"
+              "upgrade to #{advisory.patched_versions.map { |v| "'#{v}'" }.join(', ')}"
             else
               "remove or disable this gem until a patch is available!"
             end

--- a/lib/bundler/audit/cli/formats/text.rb
+++ b/lib/bundler/audit/cli/formats/text.rb
@@ -105,7 +105,7 @@ module Bundler
 
             unless advisory.patched_versions.empty?
               say "Solution: upgrade to ", :red
-              say advisory.patched_versions.join(" or ")
+              say advisory.patched_versions.map { |v| "'#{v}'" }.join(', ')
             else
               say "Solution: ", :red
               say "remove or disable this gem until a patch is available!", [:red, :bold]

--- a/spec/cli/formats/junit_spec.rb
+++ b/spec/cli/formats/junit_spec.rb
@@ -241,7 +241,7 @@ describe Bundler::Audit::CLI::Formats::Junit do
 
         context "when Advisory#patched_versions is not empty" do
           it 'must print "Solution: upgrade to ..."' do
-            expect(output).to include("Solution: upgrade to #{CGI.escapeHTML(advisory.patched_versions.join(' or '))}")
+            expect(output).to include("Solution: upgrade to #{CGI.escapeHTML(advisory.patched_versions.map { |v| "'#{v}'" }.join(', '))}")
           end
         end
 

--- a/spec/cli/formats/text_spec.rb
+++ b/spec/cli/formats/text_spec.rb
@@ -230,7 +230,7 @@ describe Bundler::Audit::CLI::Formats::Text do
 
         context "when Advisory#patched_versions is not empty" do
           it 'must print "Solution: upgrade to ..."' do
-            expect(output_lines).to include("Solution: upgrade to #{advisory.patched_versions.join(' or ')}")
+            expect(output_lines).to include("Solution: upgrade to #{advisory.patched_versions.map { |v| "'#{v}'" }.join(', ')}")
           end
         end
 


### PR DESCRIPTION
Wrapping the suggested patched version in quotes provides better separation and readability.

Original suggestion:
https://github.com/rubysec/bundler-audit/pull/327#issuecomment-1055666267

@postmodern 