### PR TITLE
Add option to fail if ignored identifiers weren't seen

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -45,6 +45,7 @@ module Bundler
       method_option :gemfile_lock, type: :string, aliases: '-G',
                                    default: 'Gemfile.lock'
       method_option :output, type: :string, aliases: '-o'
+      method_option :strict_ignore, type: :boolean, default: false
 
       def check(dir=Dir.pwd)
         unless File.directory?(dir)
@@ -86,6 +87,7 @@ module Bundler
         output.close if options[:output]
 
         exit(1) if report.vulnerable?
+        exit(1) if options[:strict_ignore] && !report.seen_identifiers.superset?(Set.new(options.ignore))
       end
 
       desc 'stats', 'Prints ruby-advisory-db stats'

--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -87,7 +87,7 @@ module Bundler
         output.close if options[:output]
 
         exit(1) if report.vulnerable?
-        exit(1) if options[:strict_ignore] && !report.seen_identifiers.superset?(Set.new(options.ignore))
+        exit(1) if options[:strict_ignore] && report.unseen_ignored_identifiers?
       end
 
       desc 'stats', 'Prints ruby-advisory-db stats'

--- a/lib/bundler/audit/cli/formats/text.rb
+++ b/lib/bundler/audit/cli/formats/text.rb
@@ -47,6 +47,10 @@ module Bundler
               end
             end
 
+            if report.unseen_ignored_identifiers?
+              print_warning "These identifiers were ignored but not found: #{report.unseen_ignored_identifiers.to_a.join(", ")}"
+            end
+
             if report.vulnerable?
               say "Vulnerabilities found!", :red
             else

--- a/lib/bundler/audit/report.rb
+++ b/lib/bundler/audit/report.rb
@@ -42,6 +42,11 @@ module Bundler
       # @return [Set<String>]
       attr_accessor :seen_identifiers
 
+      # Identifiers that were omitted from results
+      #
+      # @return [Set<String>]
+      attr_accessor :ignored_identifiers
+
       #
       # Initializes the report.
       #
@@ -55,6 +60,7 @@ module Bundler
         @insecure_sources = []
         @unpatched_gems = []
         @seen_identifiers = Set.new
+        @ignored_identifiers = Set.new
 
         results.each { |result| self << result }
       end

--- a/lib/bundler/audit/report.rb
+++ b/lib/bundler/audit/report.rb
@@ -37,6 +37,11 @@ module Bundler
       # @return [Array<Results::UnpatchedGems>]
       attr_reader :unpatched_gems
 
+      # Identifiers of all seen vulnerabilities (including ignored vulns).
+      #
+      # @return [Set<String>]
+      attr_accessor :seen_identifiers
+
       #
       # Initializes the report.
       #
@@ -49,6 +54,7 @@ module Bundler
         @results = []
         @insecure_sources = []
         @unpatched_gems = []
+        @seen_identifiers = Set.new
 
         results.each { |result| self << result }
       end

--- a/lib/bundler/audit/report.rb
+++ b/lib/bundler/audit/report.rb
@@ -145,6 +145,14 @@ module Bundler
         @unpatched_gems.map(&:gem)
       end
 
+      def unseen_ignored_identifiers?
+        unseen_ignored_identifiers.any?
+      end
+
+      def unseen_ignored_identifiers
+        @ignored_identifiers - @seen_identifiers
+      end
+
       #
       # @return [Hash{Symbol => Object}]
       #

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -121,6 +121,8 @@ module Bundler
           yield result if block_given?
         end
 
+        report.seen_identifiers = @seen
+
         return report
       end
 
@@ -222,9 +224,11 @@ module Bundler
                  else
                    config.ignore
                  end
+        @seen = Set.new
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
+            @seen.merge(advisory.identifiers)
             is_ignored = ignore.intersect?(advisory.identifiers.to_set)
             next if is_ignored
 

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -122,6 +122,12 @@ module Bundler
         end
 
         report.seen_identifiers = @seen
+        report.ignored_identifiers = ignore = if options[:ignore]
+                                                Set.new(options[:ignore])
+                                              else
+                                                config.ignore
+                                              end
+
 
         return report
       end

--- a/spec/cli/formats/text_spec.rb
+++ b/spec/cli/formats/text_spec.rb
@@ -266,6 +266,19 @@ describe Bundler::Audit::CLI::Formats::Text do
       end
     end
 
+    context "when there are unseen ignored identifiers" do
+      let(:report) do
+        Bundler::Audit::Report.new.tap do |r|
+          r.ignored_identifiers = Set.new(unseen)
+        end
+      end
+      let(:unseen) { %w[CVE-2020-8833 OSVDB-108664] }
+
+      it "must print the unseen identifiers" do
+        expect(output_lines).to include("These identifiers were ignored but not found: #{unseen.join(", ")}")
+      end
+    end
+
     it "must restore $stdout" do
       expect($stdout).to_not be(stdout)
     end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -175,4 +175,26 @@ describe Bundler::Audit::CLI do
       end
     end
   end
+
+  describe "#check" do
+    context "--strict-ignore" do
+      let(:directory) { File.join("spec", "bundle", "secure") }
+
+      subject do
+        described_class.new([], strict_ignore: true, ignore: ["CVE-2006-1982"], format: "text", database: File.expand_path("fixtures/database/", File.dirname(__FILE__)), gemfile_lock: "Gemfile.lock", config: ".bundler-audit.yml")
+      end
+
+
+      context "when the ignored CVE is not found" do
+        it "exits with an error status code" do
+          expect {
+            subject.check(directory)
+          }.to raise_error(SystemExit) do |error|
+            expect(error.success?).to eq(false)
+            expect(error.status).to eq(1)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -116,6 +116,22 @@ describe Scanner do
       expect(report.results).to all(be_kind_of(Bundler::Audit::Results::Result))
     end
 
+    it "should return a Report containing all identifiers seen during scanning" do
+      report = subject.report
+      expected_identifiers = %w[CVE-2013-0155 CVE-2013-0276 CVE-2013-1854 CVE-2013-1856 CVE-2014-3482 CVE-2015-3227 CVE-2015-7577 OSVDB-108664 OSVDB-89025 OSVDB-90072 OSVDB-91451 OSVDB-91453]
+
+      expect(report.seen_identifiers).to contain_exactly(*expected_identifiers)
+    end
+
+    context "when some identifiers are ignored" do
+      it "should return a Report containing the seen but ignored identifiers" do
+        ignored_identifiers = %w[CVE-2013-0155 OSVDB-108664]
+        report = subject.report(ignore: ignored_identifiers)
+
+        expect(report.seen_identifiers).to include(*ignored_identifiers)
+      end
+    end
+
     context "when given a block" do
       it "should yield results" do
         results = []

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -36,12 +36,12 @@ describe Scanner do
       end
 
       context "when the :ignore option is given" do
-        subject { super().scan(ignore: ['OSVDB-89026']) }
+        subject { super().scan(ignore: ['OSVDB-89025']) }
 
         it "should ignore the specified advisories" do
           ids = subject.map { |result| result.advisory.id }
 
-          expect(ids).not_to include('OSVDB-89026')
+          expect(ids).not_to include('OSVDB-89025')
         end
       end
     end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -130,6 +130,13 @@ describe Scanner do
 
         expect(report.seen_identifiers).to include(*ignored_identifiers)
       end
+
+      it "should return a Report listing the ignored identifiers" do
+        ignored_identifiers = %w[CVE-2013-0155 OSVDB-108664]
+        report = subject.report(ignore: ignored_identifiers)
+
+        expect(report.ignored_identifiers).to contain_exactly(*ignored_identifiers)
+      end
     end
 
     context "when given a block" do


### PR DESCRIPTION
I frequently use `bundler-audit` as a step in my CI/CD pipeline and will add an identifier to the `ignore` list to acknowledge that I know about the vulnerability but aren't able to upgrade the gem yet.  In order to keep that list of ignored CVEs manageable, I would like `bundler-audit` to (optionally) fail if I've ignored an identifier but the scan did not find that identifier.  This would force me to clean up the list of ignored identifiers after upgrading a gem.

This change will only output a warning message when using the `text` format because I couldn't think of a non-breaking way to add it to the JSON and XML outputs.  Maybe the option should be restricted to just the `text` format?  It would probably be annoying to return an error code without providing an explanation about why.