### PR TITLE
Fixes --gemfile-lock example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Ignore specific advisories:
 
 Checking a custom `Gemfile.lock` file:
 
-    $ bundle-audit check --gemfile Gemfile.custom.lock
+    $ bundle-audit check --gemfile-lock Gemfile.custom.lock
 
 Output the audit's results in JSON:
 


### PR DESCRIPTION
Pr. https://github.com/rubysec/bundler-audit/issues/178 the parameter is --gemfile-lock