### PR TITLE
fix: don't include test files in gem pkg

### DIFF
--- a/bundler-audit.gemspec
+++ b/bundler-audit.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.files = if gemspec['files']
                 glob[gemspec['files']]
               else
-                `git ls-files`.split($/)
+                Dir.glob(%w[bin/**/* lib/**/* bundler-audit.gemspec ChangeLog.md COPYING.txt gemspec.yml README.md])
               end
 
   gem.executables = gemspec.fetch('executables') do
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.default_executable = gem.executables.first if Gem::VERSION < '1.7.'
 
   gem.extensions       = glob[gemspec['extensions'] || 'ext/**/extconf.rb']
-  gem.test_files       = glob[gemspec['test_files'] || '{test/{**/}*_test.rb']
+  gem.test_files       = glob[gemspec['test_files'] || '{spec/{**/}*_spec.rb']
   gem.extra_rdoc_files = glob[gemspec['extra_doc_files'] || '*.{txt,md}']
 
   gem.require_paths = Array(gemspec.fetch('require_paths') {


### PR DESCRIPTION
Spec files include Gemfiles with known vulnerabilities in them (on purpose), but if scanned by a naive scanner (that is looking for any Gemfile in the system), this can cause false positives.

In addition to not including this gem in production systems, we can also just remove the specs from being included in the gem package in the first place.


How to validate
---------------

Locally, I built the project, and ran `rake build` to build the gem.

Afterwards, I ran the following to determine which files were included:

```console
$ tar -xOzf pkg/bundler-audit-0.9.0.1.gem data.tar.gz | tar -tzf -
```

And validated that the `spec/` dir was included in the list.  I committed the changes for this PR, and then had the following result:

```console
$ tar -xOzf pkg/bundler-audit-0.9.0.1.gem data.tar.gz | tar -tzf -
COPYING.txt
ChangeLog.md
README.md
bin/bundle-audit
bin/bundler-audit
bundler-audit.gemspec
gemspec.yml
lib/bundler/audit.rb
lib/bundler/audit/advisory.rb
lib/bundler/audit/cli.rb
lib/bundler/audit/cli/formats.rb
lib/bundler/audit/cli/formats/json.rb
lib/bundler/audit/cli/formats/junit.rb
lib/bundler/audit/cli/formats/text.rb
lib/bundler/audit/cli/thor_ext/shell/basic/say_error.rb
lib/bundler/audit/configuration.rb
lib/bundler/audit/database.rb
lib/bundler/audit/report.rb
lib/bundler/audit/results.rb
lib/bundler/audit/results/insecure_source.rb
lib/bundler/audit/results/result.rb
lib/bundler/audit/results/unpatched_gem.rb
lib/bundler/audit/scanner.rb
lib/bundler/audit/task.rb
lib/bundler/audit/version.rb
```