### PR TITLE
Don't double build Dependabot PRs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   tests:


### PR DESCRIPTION
Since they're all done through PRs, the Dependabot branch pushes don't need to be built on top