### PR TITLE
Fix licenses spec

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -1,7 +1,7 @@
 name: bundler-audit
 summary: Patch-level verification for Bundler
 description: bundler-audit provides patch-level verification for Bundled apps.
-license: GPL-3.0+
+license: GPL-3.0-or-later
 authors: Postmodern
 email: postmodern.mod3@gmail.com
 homepage: https://github.com/rubysec/bundler-audit#readme


### PR DESCRIPTION
As listed in https://spdx.org/licenses/, the license identifier `GPL-3.0+` is deprecated. 

I replaced it with `GPL-3.0-or-later`, in order to follow the SPDX specification.
Also, I changed the `license` key in `gemspec.yml`, to `licenses`, in order to match [naming in gem specification](https://guides.rubygems.org/specification-reference/).