### PR TITLE
Added gem metadata and corrected links in gemspec.yml

### DIFF
--- a/bundler-audit.gemspec
+++ b/bundler-audit.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.authors     = Array(gemspec['authors'])
   gem.email       = gemspec['email']
   gem.homepage    = gemspec['homepage']
+  gem.metadata    = gemspec['metadata'] if gemspec['metadata']
 
   glob = lambda { |patterns| gem.files & Dir[*patterns] }
 

--- a/gemspec.yml
+++ b/gemspec.yml
@@ -8,9 +8,9 @@ homepage: https://github.com/rubysec/bundler-audit#readme
 
 metadata:
   documentation_uri: https://rubydoc.info/gems/bundler-audit
-  source_code_uri:   https://github.com/rubysec/bundler-audit.rb
-  bug_tracker_uri:   https://github.com/rubysec/bundler-audit.rb/issues
-  changelog_uri:     https://github.com/rubysec/bundler-audit.rb/blob/master/ChangeLog.md
+  source_code_uri:   https://github.com/rubysec/bundler-audit
+  bug_tracker_uri:   https://github.com/rubysec/bundler-audit/issues
+  changelog_uri:     https://github.com/rubysec/bundler-audit/blob/master/ChangeLog.md
   rubygems_mfa_required: 'true'
 
 required_ruby_version: ">= 2.0.0"


### PR DESCRIPTION
Currently, while `gemspec.yml` includes metadata links for documentation, issue tracker, and other, the section is not used in the gemspec. This change corrects that.

In addition, I have noticed that the links are incorrect and point to no longer relevant repository name `bundler-audit.rb`.

## Difference on RubyGems

On the [RubyGems page](https://rubygems.org/gems/bundler-audit), most of the links were inferred from `homepage`, so there is a link to source code and documentation and the only on missing is "Changelog".

## Metadata difference

To test, I built the gem with rake build and compared the listing before and after the change:

```bash
tar -xOzf pkg/bundler-audit-0.9.2.gem metadata.gz | gunzip
```

Full diff:

```diff
--- before.txt	2024-09-12 07:08:08
+++ after.txt	2024-09-12 07:07:32
@@ -129,6 +129,10 @@
 licenses:
 - GPL-3.0-or-later
 metadata:
+  documentation_uri: https://rubydoc.info/gems/bundler-audit
+  source_code_uri: https://github.com/rubysec/bundler-audit
+  bug_tracker_uri: https://github.com/rubysec/bundler-audit/issues
+  changelog_uri: https://github.com/rubysec/bundler-audit/blob/master/ChangeLog.md
   rubygems_mfa_required: 'true'
 post_install_message:
 rdoc_options: []
```