### PR TITLE
Remove Dir.chdir for thread-safety

### DIFF
--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -141,7 +141,9 @@ describe Bundler::Audit::Database do
       before { stub_const("#{described_class}::DEFAULT_PATH",dest_dir) }
 
       it "should execute `git pull`" do
-        expect_any_instance_of(subject).to receive(:system).with('git', 'pull', 'origin', 'master').and_return(true)
+        status = instance_double('Process::Status', success?: true)
+        expect(Open3).to receive(:capture2).with('git', 'pull', 'origin', 'master', chdir: dest_dir)
+                                           .and_return([anything, status])
 
         subject.update!(quiet: false)
       end
@@ -150,7 +152,9 @@ describe Bundler::Audit::Database do
 
       context "when the `git pull` fails" do
         it do
-          expect_any_instance_of(subject).to receive(:system).with('git', 'pull', 'origin', 'master').and_return(false)
+          status = instance_double('Process::Status', success?: false)
+          expect(Open3).to receive(:capture2).with('git', 'pull', 'origin', 'master', chdir: dest_dir)
+                                             .and_return([anything, status])
 
           expect(subject.update!(quiet: false)).to eq(false)
         end
@@ -224,14 +228,18 @@ describe Bundler::Audit::Database do
   describe "#update!" do
     context "when the database is a git repository" do
       it do
-        expect(subject).to receive(:system).with('git', 'pull', 'origin', 'master').and_return(true)
+        status = instance_double('Process::Status', success?: true)
+        expect(Open3).to receive(:capture2).with('git', 'pull', 'origin', 'master', chdir: Fixtures::Database::PATH)
+                                           .and_return([anything, status])
 
         subject.update!
       end
 
       context "when the :quiet option is given" do
         it do
-          expect(subject).to receive(:system).with('git', 'pull', '--quiet', 'origin', 'master').and_return(true)
+          status = instance_double('Process::Status', success?: true)
+          expect(Open3).to receive(:capture2).with('git', 'pull', '--quiet', 'origin', 'master', chdir: Fixtures::Database::PATH)
+                                             .and_return([anything, status])
 
           subject.update!(quiet: true)
         end
@@ -239,7 +247,9 @@ describe Bundler::Audit::Database do
 
       context "when the `git pull` command fails" do
         it do
-          expect(subject).to receive(:system).with('git', 'pull', 'origin', 'master').and_return(false)
+          status = instance_double('Process::Status', success?: false)
+          expect(Open3).to receive(:capture2).with('git', 'pull', 'origin', 'master', chdir: Fixtures::Database::PATH)
+                                             .and_return([anything, status])
 
           expect {
             subject.update!


### PR DESCRIPTION
Currently, `Bundler::Audit::Database#update!`, `#commit_id` and `#last_updated_at` fail in multi-threaded environments (like background processing jobs) because they use `Dir.chdir`.

[From Ruby docs](https://docs.ruby-lang.org/en/3.3/Dir.html#method-c-chdir) on `Dir.chdir`:
> In a multi-threaded program an error is raised if a thread attempts to open a chdir block while another thread has one open, or a call to chdir without a block occurs inside a block passed to chdir (even in the same thread).

This PR removes the need for `Dir.chdir` by using [`Open3.capture2`](https://docs.ruby-lang.org/en/3.3/Open3.html#method-i-capture2) from the stdlib with the [`chdir` option](https://docs.ruby-lang.org/en/3.3/Process.html#module-Process-label-Working+Directory+-28-3Achdir-29).

External behavior should stay the same: `Dir.chdir` raises an `Errno::ENOENT` error given an non-existent directory, and the same holds with the new implementation.

Fixes https://github.com/rubysec/bundler-audit/issues/156

