### PR TITLE
Add env variable to enable custom repository for ruby-advisory-db

### DIFF
--- a/lib/bundler/audit/database.rb
+++ b/lib/bundler/audit/database.rb
@@ -35,7 +35,7 @@ module Bundler
       end
 
       # Git URL of the ruby-advisory-db.
-      URL = 'https://github.com/rubysec/ruby-advisory-db.git'
+      URL = ENV.fetch('RUBY_ADVISORY_DB_REPOSITORY','https://github.com/rubysec/ruby-advisory-db.git')
 
       # Path to the user's copy of the ruby-advisory-db.
       USER_PATH = File.expand_path(File.join(Gem.user_home,'.local','share','ruby-advisory-db'))


### PR DESCRIPTION
Currently the advisories are always pulled from the official GitHub repository which always requires an internet connection. If your CI agent is not connected to the internet, it is currently not possible to update the database. With the introduction of an optional env variable, user can set their internal mirror instead.

I know this is a kinda weird change, since getting the most important information (aka vulnerabilities) not from the official sources but rather than from a mirror, seems like a bad idea. But since the env variable is still optional, people who use the variable should know what they are doing. 

I couldn't find any place where all available env variables are documented, if you have any idea where to put this information, please let me know and I will add some information.