### PR TITLE
Introduce logic for cvss_v4 severity

### DIFF
--- a/lib/bundler/audit/advisory.rb
+++ b/lib/bundler/audit/advisory.rb
@@ -31,6 +31,7 @@ module Bundler
                                 :description,
                                 :cvss_v2,
                                 :cvss_v3,
+                                :cvss_v4,
                                 :cve,
                                 :osvdb,
                                 :ghsa,
@@ -77,6 +78,7 @@ module Bundler
           data['description'],
           data['cvss_v2'],
           data['cvss_v3'],
+          data['cvss_v4'],
           data['cve'],
           data['osvdb'],
           data['ghsa'],
@@ -136,8 +138,8 @@ module Bundler
       #   The criticality of the vulnerability based on the CVSS score.
       #
       def criticality
-        if cvss_v3
-          case cvss_v3
+        if cvss_v4 || cvss_v3
+          case cvss_v4 || cvss_v3
           when 0.0       then :none
           when 0.1..3.9  then :low
           when 4.0..6.9  then :medium

--- a/spec/advisory_spec.rb
+++ b/spec/advisory_spec.rb
@@ -86,6 +86,11 @@ describe Bundler::Audit::Advisory do
       it { is_expected.to eq(data['cvss_v3'])     }
     end
 
+    describe '#cvss_v4' do
+      subject { super().cvss_v4 }
+      it { is_expected.to eq(data['cvss_v4'])     }
+    end
+
     describe '#description' do
       subject { super().description }
       it { is_expected.to eq(data['description']) }
@@ -284,6 +289,56 @@ describe Bundler::Audit::Advisory do
       subject do
         described_class.new.tap do |advisory|
           advisory.cvss_v3 = 10.0
+        end
+      end
+
+      it { expect(subject.criticality).to eq(:critical) }
+    end
+
+    context "when cvss_v4 is 0.0" do
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v4 = 0.0
+        end
+      end
+
+      it { expect(subject.criticality).to eq(:none) }
+    end
+
+    context "when cvss_v4 is between 0.1 and 3.9" do
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v4 = 3.9
+        end
+      end
+
+      it { expect(subject.criticality).to eq(:low) }
+    end
+
+    context "when cvss_v4 is between 4.0 and 6.9" do
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v4 = 6.9
+        end
+      end
+
+      it { expect(subject.criticality).to eq(:medium) }
+    end
+
+    context "when cvss_v4 is between 7.0 and 8.9" do
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v4 = 8.9
+        end
+      end
+
+      it { expect(subject.criticality).to eq(:high) }
+    end
+
+    context "when cvss_v4 is between 9.0 and 10.0" do
+      subject do
+        described_class.new.tap do |advisory|
+          advisory.cvss_v4 = 10.0
         end
       end
 

--- a/spec/cli/formats/junit_spec.rb
+++ b/spec/cli/formats/junit_spec.rb
@@ -111,8 +111,76 @@ describe Bundler::Audit::CLI::Formats::Junit do
           end
         end
 
+        context "when CVSS v4 is present" do
+          context "when Advisory#criticality is :none" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 0.0
+              end
+            end
+
+            it "must print 'Criticality: None'" do
+              expect(output).to include("Criticality: None")
+            end
+          end
+
+          context "when Advisory#criticality is :low" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 0.1
+              end
+            end
+
+            it "must print 'Criticality: Low'" do
+              expect(output).to include("Criticality: Low")
+            end
+          end
+
+          context "when Advisory#criticality is :medium" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 4.0
+              end
+            end
+
+            it "must print 'Criticality: Medium'" do
+              expect(output).to include("Criticality: Medium")
+            end
+          end
+
+          context "when Advisory#criticality is :high" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 7.0
+              end
+            end
+
+            it "must print 'Criticality: High'" do
+              expect(output).to include("Criticality: High")
+            end
+          end
+
+          context "when Advisory#criticality is :critical" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 9.0
+              end
+            end
+
+            it "must print 'Criticality: High'" do
+              expect(output).to include("Criticality: Critical")
+            end
+          end
+        end
+
         context "when CVSS v3 is present" do
-          context "when Advisory#criticality is :none (cvss_v3 only)" do
+          let(:advisory) do
+            super().tap do |advisory|
+              advisory.cvss_v4 = nil
+            end
+          end
+
+          context "when Advisory#criticality is :none" do
             let(:advisory) do
               super().tap do |advisory|
                 advisory.cvss_v3 = 0.0
@@ -160,7 +228,7 @@ describe Bundler::Audit::CLI::Formats::Junit do
             end
           end
 
-          context "when Advisory#criticality is :critical (cvss_v3 only)" do
+          context "when Advisory#criticality is :critical" do
             let(:advisory) do
               super().tap do |advisory|
                 advisory.cvss_v3 = 9.0
@@ -177,6 +245,7 @@ describe Bundler::Audit::CLI::Formats::Junit do
           let(:advisory) do
             super().tap do |advisory|
               advisory.cvss_v3 = nil
+              advisory.cvss_v4 = nil
             end
           end
 

--- a/spec/cli/formats/text_spec.rb
+++ b/spec/cli/formats/text_spec.rb
@@ -104,8 +104,76 @@ describe Bundler::Audit::CLI::Formats::Text do
           end
         end
 
+        context "when CVSS v4 is present" do
+          context "when Advisory#criticality is :none" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 0.0
+              end
+            end
+
+            it "must print 'Criticality: None'" do
+              expect(output_lines).to include("Criticality: None")
+            end
+          end
+
+          context "when Advisory#criticality is :low" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 0.1
+              end
+            end
+
+            it "must print 'Criticality: Low'" do
+              expect(output_lines).to include("Criticality: Low")
+            end
+          end
+
+          context "when Advisory#criticality is :medium" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 4.0
+              end
+            end
+
+            it "must print 'Criticality: Medium'" do
+              expect(output_lines).to include("Criticality: Medium")
+            end
+          end
+
+          context "when Advisory#criticality is :high" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 7.0
+              end
+            end
+
+            it "must print 'Criticality: High'" do
+              expect(output_lines).to include("Criticality: High")
+            end
+          end
+
+          context "when Advisory#criticality is :critical" do
+            let(:advisory) do
+              super().tap do |advisory|
+                advisory.cvss_v4 = 9.0
+              end
+            end
+
+            it "must print 'Criticality: High'" do
+              expect(output_lines).to include("Criticality: Critical")
+            end
+          end
+        end
+
         context "when CVSS v3 is present" do
-          context "when Advisory#criticality is :none (cvss_v3 only)" do
+          let(:advisory) do
+            super().tap do |advisory|
+              advisory.cvss_v4 = nil
+            end
+          end
+
+          context "when Advisory#criticality is :none" do
             let(:advisory) do
               super().tap do |advisory|
                 advisory.cvss_v3 = 0.0
@@ -153,7 +221,7 @@ describe Bundler::Audit::CLI::Formats::Text do
             end
           end
 
-          context "when Advisory#criticality is :critical (cvss_v3 only)" do
+          context "when Advisory#criticality is :critical" do
             let(:advisory) do
               super().tap do |advisory|
                 advisory.cvss_v3 = 9.0
@@ -170,6 +238,7 @@ describe Bundler::Audit::CLI::Formats::Text do
           let(:advisory) do
             super().tap do |advisory|
               advisory.cvss_v3 = nil
+              advisory.cvss_v4 = nil
             end
           end
 

--- a/spec/fixtures/advisory/CVE-2020-1234.yml
+++ b/spec/fixtures/advisory/CVE-2020-1234.yml
@@ -11,6 +11,7 @@ description: |
 
 cvss_v2: 10.0
 cvss_v3: 9.8
+cvss_v4: 9.9
 
 unaffected_versions:
   - "< 0.1.0"


### PR DESCRIPTION
Hello Team,

I would like to introduce logic for properly rating severity for vulnerabilities which are estimated using only `CVSS:4.0`. This is a followup to https://github.com/rubysec/ruby-advisory-db/pull/654/

Currently vulnerabilities which are estimated using only `CVSS:4.0` are using default fallback and are being marked as `severity:unknown`.

According to specification docs I think severity did not change between 3.0 and 4.0 standards 
* https://www.first.org/cvss/v3-0/specification-document
* https://www.first.org/cvss/v4-0/specification-document

I did some refactoring based on code climate suggestions

Here is an example: 
* [SAML vulnerabilities](https://github.com/rubysec/ruby-advisory-db/pull/861/files)

Using `bundler-audit:0.9.2`

```
Name: ruby-saml
Version: 1.17.0
CVE: CVE-2025-25293
GHSA: GHSA-92rq-c8cf-prrq
Criticality: Unknown
URL: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-92rq-c8cf-prrq
Title: Ruby SAML allows remote Denial of Service (DoS) with compressed SAML responses
Solution: update to '~> 1.12.4', '>= 1.18.0'
```

Using `bundler-audit:0.10.0`
```
Name: ruby-saml
Version: 1.17.0
CVE: CVE-2025-25293
GHSA: GHSA-92rq-c8cf-prrq
Criticality: High
URL: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-92rq-c8cf-prrq
Title: Ruby SAML allows remote Denial of Service (DoS) with compressed SAML responses
Solution: update to '~> 1.12.4', '>= 1.18.0'
```

Let me know if there is anything else I should adjust