### PR TITLE
Fix different database path used for `check` command

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -39,7 +39,7 @@ module Bundler
       method_option :ignore, type: :array, aliases: '-i'
       method_option :update, type: :boolean, aliases: '-u'
       method_option :database, type: :string, aliases: '-D',
-                               default: Database::USER_PATH
+                               default: Database.path
       method_option :format, type: :string, default: 'text', aliases: '-F'
       method_option :config, type: :string, aliases: '-c', default: '.bundler-audit.yml'
       method_option :gemfile_lock, type: :string, aliases: '-G',


### PR DESCRIPTION
If the database path is overridden with the environment variable `BUNDLER_AUDIT_DB`,  the `check` command doesn't take it into account, while `download`, `update` and `stats` do.

This fix ensure `check` use the same method as the other commands to find the default path to the database.