### PR TITLE
Rake task registers database path for rake-cleaning

### DIFF
--- a/lib/bundler/audit/task.rb
+++ b/lib/bundler/audit/task.rb
@@ -12,8 +12,8 @@ module Bundler
       #
       # Initializes the task.
       #
-      def initialize
-        define
+      def initialize(clean: false)
+        define(clean:)
       end
 
       #
@@ -88,7 +88,9 @@ module Bundler
       #
       # Defines the `bundle:audit` and `bundle:audit:update` task.
       #
-      def define
+      def define(clean:)
+        register_clean if clean
+
         namespace :bundle do
           namespace :audit do
             desc 'Checks the Gemfile.lock for insecure dependencies'
@@ -108,6 +110,13 @@ module Bundler
         task 'bundler:audit'        => 'bundle:audit'
         task 'bundler:audit:check'  => 'bundle:audit:check'
         task 'bundler:audit:update' => 'bundle:audit:update'
+      end
+
+      def register_clean
+        require 'rake/clean'
+        require 'bundler/audit/database'
+
+        CLOBBER.include Bundler::Audit::Database.path
       end
     end
   end


### PR DESCRIPTION
Rake ships with clean and clobber tasks out of the box. Now the audit Task can be (optionally) registered for cleaning.

It defaults to off so no change from current behavior. If opted-in, the audit-database path is added to rake's CLOBBER collection.

Clean is meant to remove temporary and generated files that are the result of "normal" application runs.
Clobber is intended to be a more exhaustive clean that returns the application's state to a "fresh cloned" state.

With these conventions, the ruby advisory db fits more cleanly (ha) into the "clobber" category.

prior art: Bundler's gem tasks itself:
https://github.com/ruby/rubygems/blob/master/bundler/lib/bundler/gem_tasks.rb#L3-L4

Bundler's tasks register the pkg path for clobbering unconditionally, but I think that makes sense given the limited scope of the pkg path. Since the ruby advisory db is written to a path _outside_ of one's project, I believe the task should be more conservative in its deletion. Hence making it opt-in.

This PR does not yet have tests. If this enhancement is a viable candidate, I can add tests and documentation.