### PR TITLE
fix(gemspec): exclude test, spec, and CI files from published gem

### DIFF
--- a/bundler-audit.gemspec
+++ b/bundler-audit.gemspec
@@ -22,8 +22,9 @@ Gem::Specification.new do |gem|
 
   glob = lambda { |patterns| gem.files & Dir[*patterns] }
 
-  gem.files = `git ls-files`.split($/)
-  gem.files = glob[gemspec['files']] if gemspec['files']
+  gem.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|\.github)/})
+  end
 
   gem.executables = gemspec.fetch('executables') do
     glob['bin/*'].map { |path| File.basename(path) }


### PR DESCRIPTION
### Summary

This change tightens up the `gem.files` configuration in `bundler-audit.gemspec`
to avoid shipping test files and CI configuration into the published gem.

#### Motivation

Avoid false positives in container image scanners like AWS Inspector, which scan 
and analyze every `Gemfile.lock` they can find in the container image. 
So for example, the also the `spec/` files under 
`/[…]/gems/bundler-audit-0.9.3/spec/bundle/secure/Gemfile.lock` are reported.


### Changes

- **Use `git ls-files -z` with null-byte splitting** instead of
  `git ls-files` with `$/` (newline). This is more robust and correctly
  handles any filenames containing newlines or other special characters.

- **Exclude `test/`, `spec/`, and `.github/` directories** from the published
  gem file list. Previously, all tracked files (including the full spec suite
  and GitHub Actions workflows) were included in the gem package. These files
  are only relevant during development and should not be distributed to gem
  consumers.

- **Remove dead `gem.files` override line.** The line
  `gem.files = glob[gemspec['files']] if gemspec['files']` was never
  evaluated in practice because `gemspec.yml` does not define a `files:` key.
  Removing it eliminates confusion and potential for unintended future
  behaviour.

### Before

```ruby
gem.files = `git ls-files`.split($/)
gem.files = glob[gemspec['files']] if gemspec['files']
```

### After

```ruby
gem.files = `git ls-files -z`.split("\x0").reject do |f|
  f.match(%r{^(test|spec|\.github)/})
end
```

### Why this matters

Shipping `spec/` files and `.github/` workflows in a published gem unnecessarily bloats the download size for end users and exposes internal CI configuration that has no value outside of the development environment. This change aligns the gemspec with the convention used by many well-maintained gems in the Ruby ecosystem.

---

### Notes on the suggestion

| Aspect | Detail |
|---|---|
| **Target repo** | `rubysec/bundler-audit` |
| **Files changed** | `bundler-audit.gemspec` only (1 file, net −2 / +3 lines) |
| **Risk** | Very low — purely a build/packaging concern, no runtime code changed |
| **Backward compat** | `gemspec.yml` has no `files:` key so the removed override line was never used |

P.S. 🤖 I've vibe coded this task for fun with github agents, just because 
I wanted to try it out. Be nice ✌️ 🌻 