### PR TITLE
exclude spec/ directory from published gem

### DIFF
--- a/bundler-audit.gemspec
+++ b/bundler-audit.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |gem|
 
   glob = lambda { |patterns| gem.files & Dir[*patterns] }
 
-  gem.files = `git ls-files`.split($/)
+  gem.files = `git ls-files`.split($/).reject do |f|
+    f.match(%r{^(spec)/})
+  end
   gem.files = glob[gemspec['files']] if gemspec['files']
 
   gem.executables = gemspec.fetch('executables') do


### PR DESCRIPTION
Hey @postmodern 

Thank you for the quick feedback. I've addressed your comments.

- exclude `spec/` directory from published gem
- follow up of #415