### PR TITLE
Add `exclude` option to skip gems by name during audit

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -37,6 +37,7 @@ module Bundler
       method_option :quiet, type: :boolean, aliases: '-q'
       method_option :verbose, type: :boolean, aliases: '-v'
       method_option :ignore, type: :array, aliases: '-i'
+      method_option :exclude, type: :array, aliases: '-e'
       method_option :update, type: :boolean, aliases: '-u'
       method_option :database, type: :string, aliases: '-D',
                                default: Database::DEFAULT_PATH
@@ -73,7 +74,7 @@ module Bundler
                      exit 1
                    end
 
-        report = scanner.report(ignore: options.ignore)
+        report = scanner.report(ignore: options.ignore, exclude: options.exclude)
 
         output = if options[:output]
                    File.new(options[:output],'w')

--- a/lib/bundler/audit/configuration.rb
+++ b/lib/bundler/audit/configuration.rb
@@ -77,6 +77,16 @@ module Bundler
             end
 
             config[:ignore] = value.children.map(&:value)
+          when 'exclude'
+            unless value.is_a?(YAML::Nodes::Sequence)
+              raise(InvalidConfigurationError,"'exclude' key found in config file, but is not an Array")
+            end
+
+            unless value.children.all? { |node| node.is_a?(YAML::Nodes::Scalar) }
+              raise(InvalidConfigurationError,"'exclude' array in config file contains a non-String")
+            end
+
+            config[:exclude] = value.children.map(&:value)
           end
         end
 
@@ -91,6 +101,13 @@ module Bundler
       attr_reader :ignore
 
       #
+      # The list of gem names to exclude from scanning.
+      #
+      # @return [Set<String>]
+      #
+      attr_reader :exclude
+
+      #
       # Initializes the configuration.
       #
       # @param [Hash] config
@@ -99,8 +116,12 @@ module Bundler
       # @option config [Array<String>] :ignore
       #   The list of advisory IDs to ignore.
       #
+      # @option config [Array<String>] :exclude
+      #   The list of gem names to exclude from scanning.
+      #
       def initialize(config={})
-        @ignore = Set.new(config[:ignore])
+        @ignore  = Set.new(config[:ignore])
+        @exclude = Set.new(config[:exclude])
       end
 
     end

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -104,6 +104,9 @@ module Bundler
       # @option options [Array<String>] :ignore
       #   The advisories to ignore.
       #
+      # @option options [Array<String>] :exclude
+      #   The gem names to exclude from scanning.
+      #
       # @yield [result]
       #   The given block will be passed the results of the scan.
       #
@@ -133,6 +136,9 @@ module Bundler
       #
       # @option options [Array<String>] :ignore
       #   The advisories to ignore.
+      #
+      # @option options [Array<String>] :exclude
+      #   The gem names to exclude from scanning.
       #
       # @yield [result]
       #   The given block will be passed the results of the scan.
@@ -202,6 +208,9 @@ module Bundler
       # @option options [Array<String>] :ignore
       #   The advisories to ignore.
       #
+      # @option options [Array<String>] :exclude
+      #   The gem names to exclude from scanning.
+      #
       # @yield [result]
       #   The given block will be passed the results of the scan.
       #
@@ -224,7 +233,15 @@ module Bundler
                    config.ignore
                  end
 
+        exclude = if options[:exclude]
+                    Set.new(options[:exclude])
+                  else
+                    config.exclude
+                  end
+
         @lockfile.specs.each do |gem|
+          next if exclude.include?(gem.name)
+
           @database.check_gem(gem) do |advisory|
             is_ignored = ignore.intersect?(advisory.identifiers.to_set)
             next if is_ignored

--- a/spec/bundle/unpatched_gems_with_exclude_configuration/.bundler-audit.yml
+++ b/spec/bundle/unpatched_gems_with_exclude_configuration/.bundler-audit.yml
@@ -1,0 +1,3 @@
+---
+exclude:
+- activerecord

--- a/spec/bundle/unpatched_gems_with_exclude_configuration/Gemfile
+++ b/spec/bundle/unpatched_gems_with_exclude_configuration/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '3.2.10'

--- a/spec/bundle/unpatched_gems_with_exclude_configuration/Gemfile.lock
+++ b/spec/bundle/unpatched_gems_with_exclude_configuration/Gemfile.lock
@@ -1,0 +1,31 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (3.2.10)
+      activesupport (= 3.2.10)
+      builder (~> 3.0.0)
+    activerecord (3.2.10)
+      activemodel (= 3.2.10)
+      activesupport (= 3.2.10)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
+    activesupport (3.2.10)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    arel (3.0.3)
+    builder (3.0.4)
+    concurrent-ruby (1.1.7)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    multi_json (1.15.0)
+    tzinfo (0.3.58)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  activerecord (= 3.2.10)
+
+BUNDLED WITH
+   2.2.0

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -53,6 +53,30 @@ describe Bundler::Audit::Configuration do
           end
         end
       end
+
+      context "when exclude is not an array" do
+        let(:path) { File.join(fixtures_dir,'bad','exclude_is_not_an_array.yml') }
+
+        it 'raises a validation error' do
+          expect { subject }.to raise_error(described_class::InvalidConfigurationError)
+        end
+      end
+
+      context 'when exclude is an array' do
+        context 'when exclude only contains strings' do
+          let(:path) { File.join(fixtures_dir,'valid_with_exclude.yml') }
+
+          it { should be_a(described_class) }
+        end
+
+        describe "when exclude contains non-strings" do
+          let(:path) { File.join(fixtures_dir,'bad','exclude_contains_a_non_string.yml') }
+
+          it "raises a validation error" do
+            expect { subject }.to raise_error(described_class::InvalidConfigurationError)
+          end
+        end
+      end
     end
   end
 
@@ -61,6 +85,11 @@ describe Bundler::Audit::Configuration do
       it "must set @ignore to an empty Set" do
         expect(subject.ignore).to be_kind_of(Set)
         expect(subject.ignore).to be_empty
+      end
+
+      it "must set @exclude to an empty Set" do
+        expect(subject.exclude).to be_kind_of(Set)
+        expect(subject.exclude).to be_empty
       end
     end
 
@@ -72,6 +101,17 @@ describe Bundler::Audit::Configuration do
       it "must initialize @ignore to contain :ignore" do
         expect(subject.ignore).to be_kind_of(Set)
         expect(subject.ignore).to be == Set.new(advisory_ids)
+      end
+    end
+
+    context "when given :exclude" do
+      let(:gem_names) { %w[activestorage actiontext] }
+
+      subject { described_class.new(exclude: gem_names) }
+
+      it "must initialize @exclude to contain :exclude" do
+        expect(subject.exclude).to be_kind_of(Set)
+        expect(subject.exclude).to be == Set.new(gem_names)
       end
     end
   end

--- a/spec/fixtures/config/bad/exclude_contains_a_non_string.yml
+++ b/spec/fixtures/config/bad/exclude_contains_a_non_string.yml
@@ -1,0 +1,4 @@
+---
+exclude:
+  - activestorage
+  - hello: world

--- a/spec/fixtures/config/bad/exclude_is_not_an_array.yml
+++ b/spec/fixtures/config/bad/exclude_is_not_an_array.yml
@@ -1,0 +1,3 @@
+---
+exclude:
+  foo: bar

--- a/spec/fixtures/config/valid_with_exclude.yml
+++ b/spec/fixtures/config/valid_with_exclude.yml
@@ -1,0 +1,7 @@
+---
+ignore:
+  - CVE-123
+  - CVE-456
+exclude:
+  - activestorage
+  - actiontext

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -169,6 +169,16 @@ describe Scanner do
           expect(ids).not_to include('CVE-2013-0156')
         end
       end
+
+      context "when the :exclude option is given" do
+        subject { super().scan(exclude: ['activerecord']) }
+
+        it "should not include results for the excluded gem" do
+          gem_names = subject.map { |result| result.gem.name }
+
+          expect(gem_names).not_to include('activerecord')
+        end
+      end
     end
 
     context "when auditing a bundle with insecure sources" do
@@ -189,6 +199,20 @@ describe Scanner do
 
       it "should print nothing when everything is fine" do
         expect(subject).to be_empty
+      end
+    end
+
+    context "when the exclude option is configured in .bundler-audit.yml" do
+      let(:bundle)    { 'unpatched_gems_with_exclude_configuration' }
+      let(:directory) { File.join('spec','bundle',bundle) }
+      let(:scanner)   { described_class.new(directory) }
+
+      subject { scanner.scan }
+
+      it "should not include results for the excluded gem" do
+        gem_names = subject.map { |result| result.gem.name }
+
+        expect(gem_names).not_to include('activerecord')
       end
     end
 


### PR DESCRIPTION
## Description

Adds an `exclude` configuration option (and `--exclude` / `-e` CLI flag) that skips entire gems by name during scanning, so they never hit the advisory database at all.

This is semantically different from `ignore` (which skips specific advisory IDs after lookup): `exclude` is a scoping decision — "this gem isn't part of my application" — while `ignore` is a risk acceptance — "I know about this CVE and accept it."

Useful for Rails apps that bundle gems they don't actually use (e.g. `activestorage`, `actiontext`, `actionmailbox`) where every new CVE triggers a false audit failure. Currently the only workaround is adding each CVE ID to the `ignore` list, which is tedious and never-ending.

## Usage

**Config file (`.bundler-audit.yml`):**
```yaml
---
ignore:
  - CVE-2024-1234
exclude:
  - activestorage
  - actiontext
```

**CLI:**
```
bundle-audit check --exclude activestorage actiontext
```

## Changes

- **`Configuration`**: new `attr_reader :exclude` (returns `Set<String>`), YAML validation mirroring `ignore`
- **`Scanner#scan_specs`**: resolves `exclude` from options or config, skips gem before advisory lookup via `next if exclude.include?(gem.name)`
- **`CLI#check`**: new `--exclude` / `-e` array option, passed through to `scanner.report`
- **Tests**: validation specs, initializer specs, scanner specs (option-based and config-file-based), new fixtures

## Test plan

- [x] New configuration validation tests (not an array, contains non-string)
- [x] New `#initialize` tests (default empty Set, given `:exclude` list)
- [x] Scanner test: `:exclude` option filters gems from results
- [x] Scanner test: exclude from `.bundler-audit.yml` config file works
- [x] All existing tests continue to pass