### PR TITLE
Combine ignored CVEs from both --config with --ignore flag

### DIFF
--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -218,11 +218,8 @@ module Bundler
       def scan_specs(options={})
         return enum_for(__method__,options) unless block_given?
 
-        ignore = if options[:ignore]
-                   Set.new(options[:ignore])
-                 else
-                   config.ignore
-                 end
+        ignore = config.ignore
+        ignore.merge(Set.new(options[:ignore])) if options[:ignore]
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -80,6 +80,17 @@ describe Scanner do
         expect(ids).not_to include('OSVDB-89025')
       end
 
+      context "when the :ignore option is given" do
+        subject { scanner.scan(ignore: ['CVE-2013-0156']) }
+
+        it "should ignore the specified advisories" do
+          ids = subject.map { |result| result.advisory.id }
+
+          expect(ids).not_to include('CVE-2013-0156')
+          expect(ids).not_to include('OSVDB-89025')
+        end
+      end
+
       context "when config path is absolute" do
         let(:bundle) { 'unpatched_gems' }
         let(:absolute_config_path) { File.absolute_path(File.join('spec','bundle','unpatched_gems_with_dot_configuration', '.bundler-audit.yml')) }


### PR DESCRIPTION
## Description

### Current state
Currently, the `--ignore` flag overwrites the ignored CVEs from a config file (`--config`): https://github.com/rubysec/bundler-audit/blob/d8af649e9bb7552b25e46e4de2aa0828e0b3076e/lib/bundler/audit/scanner.rb#L221-L225

With `config.options` coming from the passed configuration file: https://github.com/rubysec/bundler-audit/blob/d8af649e9bb7552b25e46e4de2aa0828e0b3076e/lib/bundler/audit/scanner.rb#L91-L95

### Why this would come in handy
In our CI pipelines, we have some template jobs that run `bundle-audit` across all projects. We also have a `.bundler-audit.yml` config file to ignore specific CVEs on a per-project basis. If we now want to ignore a CVE across all projects, we have to add the CVE to the ignore file in each project. If the CVEs from the  "global" `--ignore` flag and the config file would be taken both into account, we could just add the CVEs to be ignored globally to the `--ignore` parameter.

### Potential implementation
Solution: merge the two sets instead of taking one or the other.

Original Issue:
https://github.com/rubysec/bundler-audit/issues/388