### PR TITLE
Dedup the scanner report for unpatched gems with more than one platform

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -73,7 +73,7 @@ module Bundler
                      exit 1
                    end
 
-        report = scanner.report(ignore: options.ignore)
+        report = scanner.report(ignore: options[:ignore], verbose: options[:verbose])
 
         output = if options[:output]
                    File.new(options[:output],'w')

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -230,7 +230,9 @@ module Bundler
           @database.check_gem(gem) do |advisory|
             is_ignored = ignore.intersect?(advisory.identifiers.to_set)
             next if is_ignored
-            next unless seen.add?([gem.name, gem.version, advisory.id])
+
+            reportable = options[:verbose] || seen.add?([gem.name, gem.version, advisory.id])
+            next unless reportable
 
             yield Results::UnpatchedGem.new(gem,advisory)
           end

--- a/lib/bundler/audit/scanner.rb
+++ b/lib/bundler/audit/scanner.rb
@@ -224,10 +224,13 @@ module Bundler
                    config.ignore
                  end
 
+        seen = Set.new
+
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
             is_ignored = ignore.intersect?(advisory.identifiers.to_set)
             next if is_ignored
+            next unless seen.add?([gem.name, gem.version, advisory.id])
 
             yield Results::UnpatchedGem.new(gem,advisory)
           end

--- a/spec/bundle/unpatched_gems/Gemfile.lock
+++ b/spec/bundle/unpatched_gems/Gemfile.lock
@@ -9,6 +9,11 @@ GEM
       activesupport (= 3.2.10)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
+    activerecord (3.2.10-aarch64-linux-gnu)
+      activemodel (= 3.2.10)
+      activesupport (= 3.2.10)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
     activesupport (3.2.10)
       i18n (~> 0.6)
       multi_json (~> 1.0)
@@ -23,6 +28,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-linux
+  aarch64-linux-gnu
 
 DEPENDENCIES
   activerecord (= 3.2.10)

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -161,11 +161,22 @@ describe Scanner do
       end
 
       context "when there is more than one platform per gem" do
-        subject { super().scan.to_a }
+        context "when '--verbose' is passed as an option to the cli" do
+          subject { super().scan(verbose: true).to_a }
 
-        it "should deduplicate the report" do
-          unpatched_gems = subject.map { |r| [r.gem.name, r.gem.version, r.advisory.id] }
-          expect(unpatched_gems.size).to eq(unpatched_gems.uniq.size)
+          it "should report one vulnerability per gem regardless of duplications" do
+            unpatched_gems = subject.map { |r| [r.gem.name, r.gem.version, r.advisory.id] }
+            expect(unpatched_gems.size).to be > unpatched_gems.uniq.size
+          end
+        end
+
+        context "when '--verbose' is not passed as an option to the cli" do
+          subject { super().scan.to_a }
+
+          it "should deduplicate the report" do
+            unpatched_gems = subject.map { |r| [r.gem.name, r.gem.version, r.advisory.id] }
+            expect(unpatched_gems.size).to eq(unpatched_gems.uniq.size)
+          end
         end
       end
 

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -160,6 +160,15 @@ describe Scanner do
         end
       end
 
+      context "when there is more than one platform per gem" do
+        subject { super().scan.to_a }
+
+        it "should deduplicate the report" do
+          unpatched_gems = subject.map { |r| [r.gem.name, r.gem.version, r.advisory.id] }
+          expect(unpatched_gems.size).to eq(unpatched_gems.uniq.size)
+        end
+      end
+
       context "when the :ignore option is given" do
         subject { super().scan(ignore: ['CVE-2013-0156']) }
 


### PR DESCRIPTION
Fixes #438.

The scanner now deduplicates the unpatched gems on `[gem.name, gem.version, advisory.id]`.

Notice that the spec can considered flaky. Without adding the `Gemfile.lock` change, it will pass as well.
Let me know if you are happy with this approach or if you prefer something more robust.