### PR TITLE
Pin rbs to >= 4.1.0.pre.2 to fix JRuby CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ group :development do
   gem 'rake'
   gem 'rubygems-tasks', '~> 0.3'
 
+  # rdoc 8 depends on rbs, which has no java platform gem before 4.1.0.pre.2.
+  # See https://github.com/ruby/rdoc/issues/1746
+  gem 'rbs', '>= 4.1.0.pre.2' if RUBY_PLATFORM == 'java'
+
   gem 'rubocop',        '~> 1.18'
 
   gem 'rspec',          '~> 3.0'


### PR DESCRIPTION
## Problem

The `jruby` CI job fails at `bundle install`:

```
Installing rbs 4.0.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
...
RuntimeError: The compiler failed to generate an executable file.
You have to install development tools first.
```

`rdoc 8` added a dependency on `rbs` (pulled in transitively: `rubygems-tasks` → `irb` → `rdoc`). Before `4.1.0.pre.2`, `rbs` shipped only a C-extension gem, so `bundle install` tries to compile a native extension — which fails on the JRuby CI runner because it has no C compiler toolchain.

Upstream: https://github.com/ruby/rdoc/issues/1746

## Fix

Pin `rbs` to `>= 4.1.0.pre.2` **on JRuby only** — that release publishes a `java` platform variant with no native extension to build. Other Rubies are unaffected and keep resolving whatever `rdoc`/`rbs` they normally would.